### PR TITLE
Update windows-whatsnew.md

### DIFF
--- a/defender-endpoint/windows-whatsnew.md
+++ b/defender-endpoint/windows-whatsnew.md
@@ -45,7 +45,7 @@ All updates contain:
 - Serviceability improvements
 - Integration improvements (Cloud, [Microsoft Defender XDR](/defender-xdr))
 
-## April-2024 (Release version: 10.8750)
+## May-2024 (Release version: 10.8750)
 
 |OS  |KB  |Release version |
 | -------- | -------- | -------- |


### PR DESCRIPTION
Fix the correct release month of the version of KB 5005292 from `April` to `May`.

Per this official document: https://support.microsoft.com/en-us/topic/microsoft-defender-for-endpoint-update-for-edr-sensor-f8f69773-f17f-420f-91f4-a8e5167284ac,  version 10.8750 was released from May 20th, NOT April.
![image](https://github.com/MicrosoftDocs/defender-docs/assets/31430559/b7cd382e-accd-4363-957f-6653e8754bd2)


We can also see the latest version which was completely released is still 10.8735. https://www.catalog.update.microsoft.com/Search.aspx?q=KB5005292.

The inaccurate release month brings up confusions to the customer that they feel they have missed this update. So, we need to fix the release month to avoid confusions.