### PR TITLE
Fix `..com` typo in Safe Links domain

### DIFF
--- a/defender-office-365/safe-links-about.md
+++ b/defender-office-365/safe-links-about.md
@@ -108,7 +108,7 @@ You can use a condition or exception only once, but the condition or exception c
 
 ## Safe Links settings for email messages
 
-Safe Links scans incoming email for known malicious hyperlinks. Scanned URLs are rewritten or _wrapped_ using the Microsoft standard URL prefix: `https://nam01.safelinks.protection..com`. After the link is rewritten, it's analyzed for potentially malicious content.
+Safe Links scans incoming email for known malicious hyperlinks. Scanned URLs are rewritten or _wrapped_ using the Microsoft standard URL prefix: `https://nam01.safelinks.protection.com`. After the link is rewritten, it's analyzed for potentially malicious content.
 
 After Safe Links rewrites a URL, the URL is rewritten even if the message is _manually_ forwarded or replied to. Wrapping is done per message recipient (both internal and external recipients). Additional links that are added to the forwarded or replied-to message are also rewritten.
 


### PR DESCRIPTION
The wrapping domain  `nam01.safelinks.protection..com` contains `..` before `com` which is not a valid domain.