### PR TITLE
Update linux-install-with-saltack.md

### DIFF
--- a/defender-endpoint/linux-install-with-saltack.md
+++ b/defender-endpoint/linux-install-with-saltack.md
@@ -174,7 +174,7 @@ Create a SaltState state file in your configuration repository (typically `/srv/
 
     install_mdatp_package:
     pkg.installed:
-    - name: matp
+    - name: mdatp
     - required: add_ms_repo
 
     copy_mde_onboarding_file:


### PR DESCRIPTION
Changed install_mdatp_package:

 - name: matp


To:

 - name: mdatp

As this typo breaks the package installation via Salt, with the wrong name.