### PR TITLE
Update configure-device-discovery.md

### DIFF
--- a/defender-endpoint/configure-device-discovery.md
+++ b/defender-endpoint/configure-device-discovery.md
@@ -15,7 +15,7 @@ ms.collection:
 ms.custom: admindeeplinkDEFENDER
 ms.topic: conceptual
 search.appverid: met150
-ms.date: 03/23/2021
+ms.date: 06/19/2024
 ---
 
 # Configure device discovery

--- a/defender-endpoint/configure-device-discovery.md
+++ b/defender-endpoint/configure-device-discovery.md
@@ -24,7 +24,6 @@ ms.date: 03/23/2021
 
 **Applies to:**
 
-- [Microsoft Defender for Endpoint Plan 1](microsoft-defender-endpoint.md)
 - [Microsoft Defender for Endpoint Plan 2](microsoft-defender-endpoint.md)
 - [Microsoft Defender XDR](/defender-xdr)
 


### PR DESCRIPTION
MDE Plan 1 does not have Device discovery as available functionality (when navigating to Settings in an environment with E3 licensing, the Device discovery tab is not available).

This would align this document with defender-endpoint/device-discovery.md.