### PR TITLE
Update mac-whatsnew.md

### DIFF
--- a/defender-endpoint/mac-whatsnew.md
+++ b/defender-endpoint/mac-whatsnew.md
@@ -58,7 +58,7 @@ Behavior monitoring monitors process behavior to detect and analyze potential th
 | Build:             | **101.24042.0008**    |
 |--------------------|-----------------------|
 | Release version:   | **20.124042.8.0**    |
-| Engine version:    | **1.1.24050.7**       |
+| Engine version:    | **1.1.24040.1**       |
 | Signature version: | **1.413.13.0**       |
 
 #### What's new

--- a/defender-endpoint/mac-whatsnew.md
+++ b/defender-endpoint/mac-whatsnew.md
@@ -6,7 +6,7 @@ author: YongRhee-MSFT
 ms.author: yongrhee
 manager: deniseb
 ms.localizationpriority: medium
-ms.date: 06/17/2024
+ms.date: 06/21/2024
 audience: ITPro
 ms.collection:
 - m365-security


### PR DESCRIPTION
Fix the incorrect Engine version for May-2024 release from `1.1.24050.7` to `1.1.24040.1`

In my test MacOS lab, installed with the latest Defender update, the Engine version is as below:
![image](https://github.com/MicrosoftDocs/defender-docs/assets/117632462/52eb3ee9-ea7a-439e-9f4a-67cd379d19be)

The inaccurate Engine version brings up confusions to the customer that they feel they don't have the latest version installed. So, we need to fix the Engine version to avoid confusions.