### PR TITLE
/var/*/ exclusion example misinformation

### DIFF
--- a/defender-endpoint/linux-exclusions.md
+++ b/defender-endpoint/linux-exclusions.md
@@ -60,7 +60,7 @@ File, folder, and process exclusions support the following wildcards:
 
 Wildcard|Description|Examples|
 ---|---|---
-\*|Matches any number of any characters including none (note if this wildcard is not used at the end of the path then it will substitute only one folder)| `/var/*/tmp` includes any file in `/var/abc/tmp` and its subdirectories, and `/var/def/tmp` and its subdirectories. It does not include `/var/abc/log` or `/var/def/log` <p> <p> `/var/*/` includes any file in `/var` and its subdirectories. 
+\*|Matches any number of any characters including none (note if this wildcard is not used at the end of the path then it will substitute only one folder)| `/var/*/tmp` includes any file in `/var/abc/tmp` and its subdirectories, and `/var/def/tmp` and its subdirectories. It does not include `/var/abc/log` or `/var/def/log` <p> <p> `/var/*/` only includes any files in its subdirectories such as `/var/abc/`, but not files directly inside `/var`. 
 ?|Matches any single character|`file?.log` includes `file1.log` and `file2.log`, but not`file123.log`
 > [!NOTE]
 > When using the * wildcard at the end of the path, it will match all files and subdirectories under the parent of the wildcard.

--- a/defender-endpoint/linux-exclusions.md
+++ b/defender-endpoint/linux-exclusions.md
@@ -15,7 +15,7 @@ ms.collection:
 ms.topic: conceptual
 ms.subservice: linux
 search.appverid: met150
-ms.date: 02/21/2024
+ms.date: 06/24/2024
 ---
 
 # Configure and validate exclusions for Microsoft Defender for Endpoint on Linux


### PR DESCRIPTION
There is some misinformation regarding Examples of excluding /var/*/, will also exclude files inside /var/. 

1 - Per demo lab test this is not true. It will only exclude any files inside subdirectories of **/var/**, such as **/var/abc/**.
2 - It will not exclude files inside the **/var/** folder.

**novian@VM05Ubuntu:~/Exclusion1$ sudo mdatp exclusion folder add --path /home/novian/Exclusion1/*/**
Folder exclusion configured successfully
**novian@VM05Ubuntu:~/Exclusion1$ sudo mdatp exclusion list
=====================================
Excluded folder
Path: "/home/novian/Exclusion1/Exclusion1-1/"
Scope: ["epp"]
=====================================**
novian@VM05Ubuntu:~/Exclusion1$ sudo mdatp exclusion list
=====================================
Excluded folder
Path: "/home/novian/Exclusion1/Exclusion1-1/"
Scope: ["epp"]
=====================================
**novian@VM05Ubuntu:~/Exclusion1$ curl -o test.txt https://secure.eicar.org/eicar.com.txt**
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    68  100    68    0     0     45      0  0:00:01  0:00:01 --:--:--    45
**novian@VM05Ubuntu:~/Exclusion1$ ls
Exclusion1-1  Exclusion1-2**
novian@VM05Ubuntu:~/Exclusion1$ cd Exclusion1-1
**novian@VM05Ubuntu:~/Exclusion1/Exclusion1-1$ curl -o test.txt https://secure.eicar.org/eicar.com.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    68  100    68    0     0     87      0 --:--:-- --:--:-- --:--:--    87
novian@VM05Ubuntu:~/Exclusion1/Exclusion1-1$ ls
test.txt**