### PR TITLE
Update comprehensive-guidance-on-linux-deployment.md

### DIFF
--- a/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -14,7 +14,7 @@ ms.collection:
 ms.topic: conceptual
 ms.subservice: linux
 search.appverid: met150
-ms.date: 05/08/2024
+ms.date: 09/10/2024
 ---
 
 # Advanced deployment guidance for Microsoft Defender for Endpoint on Linux
@@ -130,8 +130,7 @@ The following table lists the supported proxy settings:
 
 #### Step 3: Verify SSL inspection isn't being performed on the network traffic
 
-To prevent man-in-the-middle attacks, all Microsoft Azure hosted traffic uses certificate pinning. As a result, SSL inspections by major firewall systems aren't allowed. You have to bypass SSL inspection for Microsoft Defender for Endpoint URLs. For additional information about the certificate pinning process, please visit the following link:
-[enterprise-certificate-pinning] (/windows/security/identity-protection/enterprise-certificate-pinning).
+To prevent man-in-the-middle attacks, all Microsoft Azure hosted traffic uses certificate pinning. As a result, SSL inspections by major firewall systems aren't allowed. You must bypass SSL inspection for Microsoft Defender for Endpoint URLs. For additional information about the certificate pinning process, see [enterprise-certificate-pinning] (/windows/security/identity-protection/enterprise-certificate-pinning).
 
 ##### Troubleshoot cloud connectivity issues
 

--- a/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -131,7 +131,7 @@ The following table lists the supported proxy settings:
 #### Step 3: Verify SSL inspection isn't being performed on the network traffic
 
 To prevent man-in-the-middle attacks, all Microsoft Azure hosted traffic uses certificate pinning. As a result, SSL inspections by major firewall systems aren't allowed. You have to bypass SSL inspection for Microsoft Defender for Endpoint URLs. For additional information about the certificate pinning process, please visit the following link:
-https://learn.microsoft.com/windows/security/identity-protection/enterprise-certificate-pinning
+[enterprise-certificate-pinning] (/windows/security/identity-protection/enterprise-certificate-pinning).
 
 ##### Troubleshoot cloud connectivity issues
 

--- a/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -131,7 +131,7 @@ The following table lists the supported proxy settings:
 #### Step 3: Verify SSL inspection isn't being performed on the network traffic
 
 To prevent man-in-the-middle attacks, all Microsoft Azure hosted traffic uses certificate pinning. As a result, SSL inspections by major firewall systems aren't allowed. You have to bypass SSL inspection for Microsoft Defender for Endpoint URLs. For additional information about the certificate pinning process, please visit the following link:
-https://learn.microsoft.com/en-us/windows/security/identity-protection/enterprise-certificate-pinning
+https://learn.microsoft.com/windows/security/identity-protection/enterprise-certificate-pinning
 
 ##### Troubleshoot cloud connectivity issues
 

--- a/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -130,7 +130,8 @@ The following table lists the supported proxy settings:
 
 #### Step 3: Verify SSL inspection isn't being performed on the network traffic
 
-To prevent man-in-the-middle attacks, all Microsoft Azure hosted traffic uses certificate pinning. As a result, SSL inspections by major firewall systems aren't allowed. You have to bypass SSL inspection for Microsoft Defender for Endpoint URLs.
+To prevent man-in-the-middle attacks, all Microsoft Azure hosted traffic uses certificate pinning. As a result, SSL inspections by major firewall systems aren't allowed. You have to bypass SSL inspection for Microsoft Defender for Endpoint URLs. For additional information about the certificate pinning process, please visit the following link:
+https://learn.microsoft.com/en-us/windows/security/identity-protection/enterprise-certificate-pinning
 
 ##### Troubleshoot cloud connectivity issues
 


### PR DESCRIPTION
Added a link that explains in great detail what the enterprise certificate pinning process Defender for Endpoint uses to keep the traffic between Endpoints and the backend cloud service secure. This is part of the important note that mentions this traffic should not be SSL inspected because it will break the certificate pinning chain. For reference, the link added is the one below
https://learn.microsoft.com/en-us/windows/security/identity-protection/enterprise-certificate-pinning