### PR TITLE
Update mac-install-with-intune.md

### DIFF
--- a/defender-endpoint/mac-install-with-intune.md
+++ b/defender-endpoint/mac-install-with-intune.md
@@ -335,7 +335,7 @@ Set policies using Microsoft Defender Portal by implementing the following instr
 
 1. Go through [Configure Microsoft Defender for Endpoint in Intune](/mem/intune/protect/advanced-threat-protection-configure) before setting the security policies using Microsoft Defender for Endpoint Security Settings Management.
 
-2. In the [Microsoft Defender portal](https://sip.security.microsoft.com/homepage?tid=72f988bf-86f1-41af-91ab-2d7cd011db47), go to **Configuration management** > **Endpoint security policies** > **Mac policies** > **Create new policy**.
+2. In the [Microsoft Defender portal](https://sip.security.microsoft.com/homepage), go to **Configuration management** > **Endpoint security policies** > **Mac policies** > **Create new policy**.
 
 3. Under **Select Platform**, select **macOS**.
 


### PR DESCRIPTION
Removed a tenant ID from the link, it looks like this was causing issues when users clicked on the link and tried to sign in. The error message: "Selected user account does not exist in tenant 'Microsoft' and cannot access the application '80ccca67-54bd-44ab-8625-4b79c4dc7775' in that tenant. The account needs to be added as an external user in the tenant first. Please use a different account."