### PR TITLE
Update safe-links-policies-configure.md to match the two articles

### DIFF
--- a/defender-office-365/safe-links-policies-configure.md
+++ b/defender-office-365/safe-links-policies-configure.md
@@ -18,7 +18,7 @@ ms.collection:
 ms.custom:
 description: Admins can learn how to view, create, modify, and delete Safe Links policies in Microsoft Defender for Office 365.
 ms.service: defender-office-365
-ms.date: 07/18/2024
+ms.date: 10/18/2024
 appliesto:
   - ✅ <a href="https://learn.microsoft.com/defender-office-365/mdo-about#defender-for-office-365-plan-1-vs-plan-2-cheat-sheet" target="_blank">Microsoft Defender for Office 365 Plan 1 and Plan 2</a>
   - ✅ <a href="https://learn.microsoft.com/defender-xdr/microsoft-365-defender" target="_blank">Microsoft Defender XDR</a>

--- a/defender-office-365/safe-links-policies-configure.md
+++ b/defender-office-365/safe-links-policies-configure.md
@@ -115,8 +115,7 @@ You configure Safe Links policies in the Microsoft Defender portal or in Exchang
        - **Apply Safe Links to email messages sent within the organization**: Select this option to apply the Safe Links policy to messages between internal senders and internal recipients. Turning on this setting enables link wrapping for all intra-organization messages.
        - **Apply real-time URL scanning for suspicious links and links that point to files**: Select this option to turn on real-time scanning of links in email messages from external senders. If you select this option, the following setting is available:
          - **Wait for URL scanning to complete before delivering the message**: Select this option to wait for real-time URL scanning to complete before delivering the message from external senders. The recommended setting is **On**.
-       - **Do not rewrite URLs, do checks via SafeLinks API only**: Select this option to prevent URL wrapping and skip reputation check during mail flow. Safe Links is called exclusively via APIs at the time of URL click by Outlook clients that support it.
-
+       - **Do not rewrite URLs, do checks via SafeLinks API only**: Select this option to prevent URL wrapping but continue the scanning of URLs prior to message delivery. In supported versions of Outlook (Windows, Mac, and Outlook on the web), Safe Links is called exclusively via APIs at the time of URL click.
      - **Do not rewrite the following URLs in email** section: Select the **Manage (nn) URLs** link to allow access to specific URLs that would otherwise be blocked by Safe Links.
 
        > [!NOTE]


### PR DESCRIPTION
https://learn.microsoft.com/en-us/defender-office-365/safe-links-about

https://learn.microsoft.com/en-us/defender-office-365/safe-links-policies-configure

Both above articles should mention that URLs scan before delivery still happens.  See https://o365exchange.visualstudio.com/IP%20Engineering/_workitems/edit/4976566