### PR TITLE
Update defender-endpoint-demonstration-smartscreen-url-reputation.md

### DIFF
--- a/defender-endpoint/defender-endpoint-demonstration-smartscreen-url-reputation.md
+++ b/defender-endpoint/defender-endpoint-demonstration-smartscreen-url-reputation.md
@@ -14,7 +14,7 @@ ms.collection:
 - demo
 ms.topic: article
 ms.subservice: asr
-ms.date: 01/15/2024
+ms.date: 10/28/2024
 ---
 
 # URL reputation demonstrations

--- a/defender-endpoint/defender-endpoint-demonstration-smartscreen-url-reputation.md
+++ b/defender-endpoint/defender-endpoint-demonstration-smartscreen-url-reputation.md
@@ -71,7 +71,7 @@ Blocked from downloading because of its URL reputation
 
 - [Download blocked due to URL reputation](https://demo.smartscreen.msft.net/download/malwaredemo/freevideo.exe)
 
-  Launching this link should render a message similar to the Malware page message.
+  Launching this link should render a warning that the download was blocked as being unsafe by Microsoft Edge.
 
 ### Exploit page
 


### PR DESCRIPTION
Blocked download from URL due to reputation updated.

There is no block screen. Upon download there is notification in the upper right hand corner in the downloads area that the download has been blocked