### PR TITLE
Update indicators-overview.md

### DIFF
--- a/defender-endpoint/indicators-overview.md
+++ b/defender-endpoint/indicators-overview.md
@@ -155,6 +155,8 @@ The IoC API schema and the threat IDs in advance hunting are updated to align wi
 > File and certificate indicators do not block [exclusions defined for Microsoft Defender Antivirus](/windows/security/threat-protection/microsoft-defender-antivirus/configure-exclusions-microsoft-defender-antivirus). Indicators are not supported in Microsoft Defender Antivirus when it is in passive mode.
 > 
 > The format for importing new indicators (IoCs) has changed according to the new updated actions and alerts settings. We recommend downloading the new CSV format that can be found at the bottom of the import panel.
+>
+> If indicators are synced to the Indicator in the MDE portal from MDCA sanctioned/unsanctioned applications, the 'Generate Alert' option will be enabled by default in the MDE portal. If you try to uncheck the 'Generate Alert' option in MDE, it will be re-enabled after some time as the MDCA policy will override it.
 
 ## Known issues and limitations
 


### PR DESCRIPTION
Need add below point as "Note" so that we could avoid support tickets from users.

If indicators are synced to the Indicator in the MDE portal from MDCA sanctioned/unsanctioned applications, the 'Generate Alert' option will be enabled by default in the MDE portal. If you try to uncheck the 'Generate Alert' option in MDE, it will be re-enabled after some time as the MDCA policy will override it