### PR TITLE
Update microsoft-defender-endpoint-linux to remove reference to x86

### DIFF
--- a/defender-endpoint/microsoft-defender-endpoint-linux.md
+++ b/defender-endpoint/microsoft-defender-endpoint-linux.md
@@ -59,7 +59,7 @@ Microsoft Defender for Endpoint for Linux includes anti-malware and endpoint det
   > [!NOTE]
   > Performance tuning might be needed based on workloads. See [Troubleshoot performance issues for Microsoft Defender for Endpoint on  Linux](linux-support-perf.md).
 
-- The following Linux server distributions and x64 (AMD64/EM64T) and x86_64 versions are supported:
+- The following Linux server distributions and x64 (AMD64/EM64T) versions are supported:
   - Red Hat Enterprise Linux 7.2 or higher
   - Red Hat Enterprise Linux 8.x
   - Red Hat Enterprise Linux 9.x

--- a/defender-endpoint/microsoft-defender-endpoint-linux.md
+++ b/defender-endpoint/microsoft-defender-endpoint-linux.md
@@ -15,7 +15,7 @@ ms.collection:
 ms.topic: conceptual
 ms.subservice: linux
 search.appverid: met150
-ms.date: 12/24/2024
+ms.date: 01/02/2025
 ---
 
 # Microsoft Defender for Endpoint on Linux


### PR DESCRIPTION
Given that AMD64 and EM64T are in fact the implementation of x86-64, let's remove the 'x86_64' reference from this article, as it does generate some confusion.

https://en.wikipedia.org/wiki/X86-64