### PR TITLE
Update links in run-analyzer-linux.md

### DIFF
--- a/defender-endpoint/run-analyzer-linux.md
+++ b/defender-endpoint/run-analyzer-linux.md
@@ -44,8 +44,8 @@ The XMDE Client Analyzer tool can be downloaded as a [binary](https://go.microso
 
 Download and extract the XMDE Client Analyzer. You can use either the binary or Python version, as follows:
 
-- [Binary version of the Client Analyzer](/defender-endpoint/run-analyzer-macos-linux)
-- [Python version of the Client Analyzer](/defender-endpoint/run-analyzer-macos-linux)
+- [Binary version of the Client Analyzer](run-analyzer-linux.md#run-the-binary-version-of-the-client-analyzer)
+- [Python version of the Client Analyzer](run-analyzer-linux.md#run-the-python-based-client-analyzer)
 
 Due to the limited commands available in live response, the steps detailed must be executed in a bash script. By splitting the installation and execution portion of these commands, it's possible to run the install script once, and run the execution script multiple times.
 
@@ -54,7 +54,7 @@ Due to the limited commands available in live response, the steps detailed must 
 
 #### Binary client analyzer install script
 
-The following script performs the first six steps of the [Running the Binary version of the Client Analyzer](/defender-endpoint/run-analyzer-macos-linux). When complete, the XMDE Client Analyzer binary is available from the `/tmp/XMDEClientAnalyzerBinary/ClientAnalyzer` directory.
+The following script performs the first six steps of the [Running the Binary version of the Client Analyzer](run-analyzer-linux.md#details). When complete, the XMDE Client Analyzer binary is available from the `/tmp/XMDEClientAnalyzerBinary/ClientAnalyzer` directory.
 
 1. Create a bash file `InstallXMDEClientAnalyzer.sh` and paste the following content into it.
 
@@ -80,7 +80,7 @@ The following script performs the first six steps of the [Running the Binary ver
 
 #### Python client analyzer install script
 
-The following script performs the first six steps of the [Running the Python version of the Client Analyzer](/defender-endpoint/run-analyzer-macos-linux). When complete, the XMDE Client Analyzer Python scripts are available from the `/tmp/XMDEClientAnalyzer` directory.
+The following script performs the first six steps of the [Running the Python version of the Client Analyzer](run-analyzer-linux.md#run-the-python-based-client-analyzer). When complete, the XMDE Client Analyzer Python scripts are available from the `/tmp/XMDEClientAnalyzer` directory.
 
 1. Create a bash file `InstallXMDEClientAnalyzer.sh` and paste the following content into it.
 


### PR DESCRIPTION
With recent changes, replaced "/defender-endpoint/run-analyzer-macos-linux" link to the corresponding location in this page with anchor.
The "/defender-endpoint/run-analyzer-macos-linux" page no longer contain instruction on downloading and running the client analyzer, instead only gives link back to this page. So, it's confusing to jump to that page only to jump back.