### PR TITLE
Update live-response.md

### DIFF
--- a/defender-endpoint/live-response.md
+++ b/defender-endpoint/live-response.md
@@ -64,7 +64,7 @@ Before you can initiate a session on a device, make sure you fulfill the followi
 
   - **Windows Server 2016** - with [KB5005292](https://support.microsoft.com/topic/microsoft-defender-for-endpoint-update-for-edr-sensor-f8f69773-f17f-420f-91f4-a8e5167284ac)
     > [!NOTE]
-    > For Windows Server 2012R2 or 2016 you must have the [Unified Agent](update-agent-mma-windows.md#update-mma-on-your-devices) installed, and it is recommended to patch to latest sensor version with KB5005292.
+    > For Windows Server 2012R2 or 2016 you must have the [Unified Agent](update-agent-mma-windows.md#update-mma-on-your-devices) installed, and it is recommended to patch to latest sensor version with KB5005292. Live Response feature will not work as expected for offline Down-Level servers onboarded via streamlined method, having static proxy. Consider using System proxy.
     
   - **Windows Server 2019**
     - Version 1903 or (with [KB4515384](https://support.microsoft.com/help/4515384/windows-10-update-kb4515384)) later


### PR DESCRIPTION
For offline Down level OS onboarded via streamline onboarding method, Live Response commands will fail. The connection fails on uploading results to azure storage. The uploading fails on CRL endpoint is offline (WINHTTP_CALLBACK_STATUS_FLAG_CERT_REV_FAILED) engineering team is working on fixing this in June 2025 Sense release