### PR TITLE
Rectify malformed image syntax

### DIFF
--- a/defender-office-365/configuration-analyzer-for-security-policies.md
+++ b/defender-office-365/configuration-analyzer-for-security-policies.md
@@ -189,7 +189,7 @@ To filter the entries, select :::image type="icon" source="media/m365-cc-sc-filt
 
 When you're finished in the **Filters** flyout, select **Apply**. To clear the filters, select :::image type="icon" source="media/m365-cc-sc-clear-filters-icon.png" border="false"::: **Clear filters**.
 
-Use the ::image type="icon" source="media/m365-cc-sc-search-icon.png" border="false"::: **Search** box to filter the entries by a specific **Modified by**, **Setting name**, or **Type** value.
+Use the :::image type="icon" source="media/m365-cc-sc-search-icon.png" border="false"::: **Search** box to filter the entries by a specific **Modified by**, **Setting name**, or **Type** value.
 
 To export the entries shown on the **Configuration drift analysis and history** tab to a .csv file, select :::image type="icon" source="media/m365-cc-sc-download-icon.png" border="false"::: **Export**.
 

--- a/defender-vulnerability-management/tvm-certificate-inventory.md
+++ b/defender-vulnerability-management/tvm-certificate-inventory.md
@@ -57,7 +57,7 @@ The **Certificate inventory** page opens with a list of the certificates install
 > [!NOTE]
 > Only certificates found on Windows devices (in the local machine certificate store) will be displayed in certificate inventory list.
 
-   :::image type="content" source="/defender/media/defender-vulnerability-management/certificate_inventory.png" alt-text="Screenshot of the certificate inventory list" lightbox="/defender/media/defender-vulnerability-management/certificate_inventory.png":::::::::
+   :::image type="content" source="/defender/media/defender-vulnerability-management/certificate_inventory.png" alt-text="Screenshot of the certificate inventory list" lightbox="/defender/media/defender-vulnerability-management/certificate_inventory.png":::
 
 ## Gain insights into potentially vulnerable certificates
 


### PR DESCRIPTION
Fix 2 instances where the image syntax is incorrect, which either causes stray colons to be rendered, or the whole image not being rendered.