### PR TITLE
Remove ill-formed space between link text and URL

### DIFF
--- a/defender-endpoint/find-defender-malware-name.md
+++ b/defender-endpoint/find-defender-malware-name.md
@@ -37,7 +37,7 @@ To find the detection name of a malware family, you need to search the internet 
 2. Search the web for *malware family* + **cyberattack + hash** to find the hash
 3. Look up the hash in [Virus Total](https://www.virustotal.com/)
 4. Find the Microsoft row and how we name the malware
-5. Look up the malware name in the [Microsoft Defender Security Intelligence website] (https://www.microsoft.com/en-us/wdsi/threats). You should see Microsoft information and guidance specific to that malware.
+5. Look up the malware name in the [Microsoft Defender Security Intelligence website](https://www.microsoft.com/en-us/wdsi/threats). You should see Microsoft information and guidance specific to that malware.
 
 For example, search for the "Sunburst cyberattack hash". One of the websites returned in the search results should have the hash. In this example, the hash is **a25cadd48d70f6ea0c4a241d99c5241269e6faccb4054e62d16784640f8e53bc**. Then, look up this hash in [Virus Total](https://www.virustotal.com/).
 

--- a/defender-office-365/defender-for-office-365-whats-new.md
+++ b/defender-office-365/defender-for-office-365-whats-new.md
@@ -53,7 +53,7 @@ For more information on what's new with other Microsoft Defender security produc
 
 ## October 2024
 
-- **Tenant Allow/Block List in Microsoft 365 now supports IPv6 address**: The [Tenant Allow/Block List](tenant-allow-block-list-about.md) now supports [allowing and blocking IPv6 addresses] (tenant-allow-block-list-ip-addresses-configure.md). It's available in Microsoft 365 Worldwide, GCC, GCC High, DoD, and Office 365 operated by 21Vianet environments.
+- **Tenant Allow/Block List in Microsoft 365 now supports IPv6 address**: The [Tenant Allow/Block List](tenant-allow-block-list-about.md) now supports [allowing and blocking IPv6 addresses](tenant-allow-block-list-ip-addresses-configure.md). It's available in Microsoft 365 Worldwide, GCC, GCC High, DoD, and Office 365 operated by 21Vianet environments.
 
 ## September 2024
 


### PR DESCRIPTION
Remove space character between link text and URL, which causes it to be rendered verbatim (instead of an actual link).