### PR TITLE
Update linux-resources.md

### DIFF
--- a/defender-endpoint/linux-resources.md
+++ b/defender-endpoint/linux-resources.md
@@ -1,3 +1,4 @@
+##Please add this page but for linux servers##
 ---
 title: Microsoft Defender for Endpoint on Linux resources
 ms.reviewer: gopkr, yujiao


### PR DESCRIPTION
Hi, apologies, this isn't actually a change for this page but I am unaware how to create a completely new page. I would like this same page for for Linux troubleshooting instead. Specifically I had an issue with no license found on Linux. This is the text there should be for that new section:

If Microsoft Defender for Endpoint on Linux has been offboarded When the offboarding script is executed on the Linux, it saves a file in /etc/opt/microsoft/mdatp and it's named mdatp_offboard.json.

If the file exists, it will prevent the Linux Server from being onboarded again. Delete the mdatp_offboard.json then run the onboarding script again.

This is the link for MACs, I would like one created for Linux Servers: https://learn.microsoft.com/en-us/defender-endpoint/mac-support-license