### PR TITLE
Fix MD typo in device-discovery-faq.md

### DIFF
--- a/defender-endpoint/device-discovery-faq.md
+++ b/defender-endpoint/device-discovery-faq.md
@@ -78,7 +78,7 @@ By default, all onboarded devices running on Windows 10 version 1809 or later, W
 - `DHCPv6`
 - `IP` (headers)
 - `LLDP`
-- LL`MNR
+- `LLMNR`
 - `mDNS`
 - `MNDP`
 - `MSSQL`


### PR DESCRIPTION
Very small fix of the formatting for LLMR in the list of protocols used in device discovery by MS Defender for Endpoint.