### PR TITLE
Adding link to the BeyondTrust Integration

### DIFF
--- a/ATPDocs/integrate-microsoft-and-pam-services.md
+++ b/ATPDocs/integrate-microsoft-and-pam-services.md
@@ -57,3 +57,5 @@ For more information, see:
 [How to integrate Defender for Identity with Delinea](https://docs.delinea.com/online-help/integrations/microsoft/mdi/integrating-mdi.htm)
 
 [How to integrate Defender for Identity with CyberArk](https://community.cyberark.com/marketplace/s/#a35Ht0000018sDVIAY-a39Ht000004GLaEIAW)
+
+[How to integrate Defender for Identity with BeyondTrust](https://docs.beyondtrust.com/insights/docs/microsoft-defender)


### PR DESCRIPTION
We got a complaint from the field that the link to the BeyonTrust documentation is missing
Added the missing link