### PR TITLE
Update technical-faq.yml

### DIFF
--- a/ATPDocs/technical-faq.yml
+++ b/ATPDocs/technical-faq.yml
@@ -92,7 +92,11 @@ sections:
       - question: Do I have the flexibility to select where to store my data?
         answer: |
           No. When your Defender for Identity workspace is created, it's stored automatically in the Azure region that's closest to your Microsoft Entra tenant's geographical location. Once your Defender for Identity workspace is created, Defender for Identity data can't be moved to a different region.
-
+      
+      - question: When using Microsoft Defender for Identity (MDI), is end-user consent required for overseas data transfer under Japan’s Act on the Protection of Personal Information (APPI)?
+        answer: |
+           No, end-user consent is not required. Providing personal data to MDI constitutes “outsourcing” rather than a “provision to a third party in a foreign country” under the APPI. Therefore, explicit end-user consent for cross-border data transfer is not necessary.
+           
       - question: How does Microsoft prevent malicious insider activities and abuse of high privilege roles?
         answer: |
           Microsoft developers and administrators have, by design, been given sufficient privileges to carry out their assigned duties to operate and evolve the service. Microsoft deploys combinations of preventive, detective, and reactive controls including the following mechanisms to help protect against unauthorized developer and/or administrative activity:


### PR DESCRIPTION
This FAQ addition addresses a common question from Japanese enterprise customers regarding compliance with the Act on the Protection of Personal Information (APPI) in the context of Microsoft Defender for Identity (MDI). Specifically, it clarifies whether end-user consent is required for overseas data transfer when using MDI.

Justification and Accuracy:
The content has been carefully reviewed against official guidance from Japan’s Personal Information Protection Commission (PPC), particularly Q&A 12-3, as well as legal commentaries. According to the PPC and current legal interpretations, providing personal data to Microsoft as part of using MDI is classified as “outsourcing” rather than a “provision to a third party in a foreign country.” Therefore, explicit end-user consent for cross-border data transfer is not required, as long as the proper contractual and supervisory safeguards are in place.

This clarification is important for legal compliance and customer assurance. The FAQ content accurately reflects the current legal requirements and aligns with both Japanese government guidance and Microsoft’s standard contractual obligations.