### PR TITLE
Update quarantine-policies.md

### DIFF
--- a/defender-office-365/quarantine-policies.md
+++ b/defender-office-365/quarantine-policies.md
@@ -745,6 +745,14 @@ The effect of **No access** permissions (admin only access) on user capabilities
 - **Quarantine notifications turned on**:
   - **On the Quarantine page**: Quarantined messages are visible to users, but the only available action is :::image type="icon" source="media/m365-cc-sc-view-message-headers-icon.png" border="false"::: [View message headers](quarantine-end-user.md#view-email-message-headers).
   - **In quarantine notifications**: Users receive quarantine notifications, but the only available action is **Review message**.
+> **Note:**  
+> 💡 The **default `AdminOnlyAccessPolicy`** is **immutable** and **always has notifications disabled**.  
+> To enable notifications while maintaining restricted access:  
+> - **Create a custom quarantine policy**  
+> - Set **Access: No access**  
+> - Configure **notifications** as needed  
+
+<!-- You may need to use a plugin or CSS styling in your Markdown tool to display this in pink -->
 
 ##### Limited access
 

--- a/defender-office-365/quarantine-policies.md
+++ b/defender-office-365/quarantine-policies.md
@@ -16,7 +16,7 @@ ms.collection:
 ms.custom:
 description: Admins can learn how to use quarantine policies to control what users are able to do to quarantined messages.
 ms.service: defender-office-365
-ms.date: 05/13/2025
+ms.date: 05/29/2025
 appliesto:
   - ✅ <a href="https://learn.microsoft.com/defender-office-365/eop-about" target="_blank">Exchange Online Protection</a>
   - ✅ <a href="https://learn.microsoft.com/defender-office-365/mdo-about#defender-for-office-365-plan-1-vs-plan-2-cheat-sheet" target="_blank">Microsoft Defender for Office 365 Plan 1 and Plan 2</a>
@@ -587,7 +587,8 @@ For detailed syntax and parameter information, see [Get-QuarantinePolicy](/power
 
 ## Modify quarantine policies in the Microsoft Defender portal
 
-You can't modify the default quarantine policies named AdminOnlyAccessPolicy, DefaultFullAccessPolicy, or DefaultFullAccessWithNotificationPolicy.
+> [!NOTE]
+> Permissions and notification settings in default quarantine policies are read only (aren't modifiable).
 
 1. In the Microsoft Defender portal at <https://security.microsoft.com>, go to **Email & collaboration** \> **Policies & rules** \> **Threat policies** \> **Quarantine policies** in the **Rules** section. Or, to go directly to the **Quarantine policies** page, use <https://security.microsoft.com/quarantinePolicies>.
 
@@ -675,6 +676,9 @@ Quarantine policies also control whether users receive _quarantine notifications
 - Inform the user that the message is in quarantine.
 - Allow users to view and take action on the quarantined message from the quarantine notification. Permissions control what the user can do in the quarantine notification as described in the [Quarantine policy permission details](#quarantine-policy-permission-details) section.
 
+> [!NOTE]
+> Permissions and notification settings in default quarantine policies are read only (aren't modifiable).
+
 The relationship between permissions, permissions groups, and the default quarantine policies are described in the following tables:
 
 |Permission|No access|Limited access|Full access|
@@ -745,14 +749,12 @@ The effect of **No access** permissions (admin only access) on user capabilities
 - **Quarantine notifications turned on**:
   - **On the Quarantine page**: Quarantined messages are visible to users, but the only available action is :::image type="icon" source="media/m365-cc-sc-view-message-headers-icon.png" border="false"::: [View message headers](quarantine-end-user.md#view-email-message-headers).
   - **In quarantine notifications**: Users receive quarantine notifications, but the only available action is **Review message**.
-> **Note:**  
-> 💡 The **default `AdminOnlyAccessPolicy`** is **immutable** and **always has notifications disabled**.  
-> To enable notifications while maintaining restricted access:  
-> - **Create a custom quarantine policy**  
-> - Set **Access: No access**  
-> - Configure **notifications** as needed  
 
-<!-- You may need to use a plugin or CSS styling in your Markdown tool to display this in pink -->
+> [!TIP]
+> To enable quarantine notifications while maintaining restricted access, [create a custom quarantine policy](#step-1-create-quarantine-policies-in-the-microsoft-defender-portal) with the following settings:
+>
+> - **Recipient message access** page: Select **Set specific access (Advanced)**, but leave **Select release action preference** and **Select additional actions recipients can take on quarantined messages** blank/unselected (equivalent to the value 0 for the _EndUserQuarantinePermissionsValue_ parameter on the **New-QuarantinePolicy** cmdlet [in Powershell](#create-quarantine-policies-in-powershell)).
+> - **Quarantine notification** page: Select **Enable** and then select **Don't include quarantined messages from blocked sender addresses** (default) or **Include quarantined messages from blocked sender addresses**.
 
 ##### Limited access
 


### PR DESCRIPTION
There was a customers' confusion we're seeing is specifically around the built-in AdminOnlyAccessPolicy, which is not editable and has the notification setting hardcoded to “Off”. This means: Admins cannot enable or disable notifications for this policy. End users should never receive notifications if this default policy is applied. The problem arises because the documentation presents notification settings as configurable, which leads some customers to believe this includes the built-in AdminOnlyAccessPolicy. As a result, they open cases wondering why end users receive notifications or asking how to turn them off—when in fact, the default policy doesn’t even allow that. (knowing that by analysis, we can share why users are receiving notifications, based on what is set for this kind of threat SCL level, maybe because it is identified SPAM and he doesn't have the AdminOnly action set for SPAM mails in his custom quarantine policy )
 
To reduce this confusion, I suggest we consider explicitly stating in documentation that: The default AdminOnlyAccessPolicy is immutable
It always has notifications disabled
If notifications are needed alongside restricted access, admins should use a custom policy with "No access" and configure notifications accordingly.

Discussed with our Beta engineer, Mithun and confirmed to update the documentation with the pulled information