### PR TITLE
Remove pre-release INCLUDE from configure-endpoints-gp.md

### DIFF
--- a/defender-endpoint/configure-endpoints-gp.md
+++ b/defender-endpoint/configure-endpoints-gp.md
@@ -21,8 +21,6 @@ search.appverid: met150
 
 [!INCLUDE [Microsoft Defender XDR rebranding](../includes/microsoft-defender.md)]
 
-[!include[Prerelease information](../includes/prerelease.md)]
-
 **Applies to:**
 
 - Group Policy


### PR DESCRIPTION
Change: 
- Remove pre-release INCLUDE

Reason:
- Customer confused about what is target of this pre-release description.
- I couldn't found any preview function on this page.