### PR TITLE
Update remediate-malicious-email-delivered-office-365.md

### DIFF
--- a/defender-office-365/remediate-malicious-email-delivered-office-365.md
+++ b/defender-office-365/remediate-malicious-email-delivered-office-365.md
@@ -14,7 +14,7 @@ ms.localizationpriority: medium
 search.appverid: MET150
 description: Threat remediation
 ms.service: defender-office-365
-ms.date: 05/19/2025
+ms.date: 07/28/2025
 appliesto:
   - ✅ <a href="https://learn.microsoft.com/defender-office-365/mdo-about#defender-for-office-365-plan-1-vs-plan-2-cheat-sheet" target="_blank">Microsoft Defender for Office 365 Plan 2</a>
 ---
@@ -106,7 +106,7 @@ Open any remediation item to view details about it, including its remediation na
 
       **Delete sender's copy**: Also try to soft delete the message from the sender's Sent Items folder if the sender is the organization.
 
-    - **Hard delete**: Purge the deleted message. Admins can recover hard deleted items using single-item recovery. For more information about hard deleted and soft deleted items, see [Soft-deleted and hard-deleted items](/compliance/assurance/assurance-exchange-online-data-deletion#soft-deleted-and-hard-deleted-items). If you use unified RBAC you also need this Permission: "Email & collaboration metadata (read)" for hard delete to work.
+    - **Hard delete**: Purge the deleted message. Admins can recover hard deleted items using single-item recovery. For more information about hard deleted and soft deleted items, see [Soft-deleted and hard-deleted items](/compliance/assurance/assurance-exchange-online-data-deletion#soft-deleted-and-hard-deleted-items). If you use [Microsoft Defender XDR Unified role based access control (RBAC)](/defender-xdr/manage-rbac), you also need the **Email & collaboration metadata (read)** permission to hard delete messages.
 
   > [!NOTE]
   > In U.S. Government organizations (Microsoft 365 GCC, GCC High, and DoD) admins can take the actions **Soft delete**, **Move to junk folder**, **Move to deleted items**, **Hard delete**, and **Move to inbox**. The actions **Delete sender's copy** and **Move to inbox** from quarantine folder aren't available. Also, the action logs are available only at <https://security.microsoft.com/threatincidents>, not in the **Action Center** at <https://security.microsoft.com/action-center>.

--- a/defender-office-365/remediate-malicious-email-delivered-office-365.md
+++ b/defender-office-365/remediate-malicious-email-delivered-office-365.md
@@ -106,7 +106,7 @@ Open any remediation item to view details about it, including its remediation na
 
       **Delete sender's copy**: Also try to soft delete the message from the sender's Sent Items folder if the sender is the organization.
 
-    - **Hard delete**: Purge the deleted message. Admins can recover hard deleted items using single-item recovery. For more information about hard deleted and soft deleted items, see [Soft-deleted and hard-deleted items](/compliance/assurance/assurance-exchange-online-data-deletion#soft-deleted-and-hard-deleted-items).
+    - **Hard delete**: Purge the deleted message. Admins can recover hard deleted items using single-item recovery. For more information about hard deleted and soft deleted items, see [Soft-deleted and hard-deleted items](/compliance/assurance/assurance-exchange-online-data-deletion#soft-deleted-and-hard-deleted-items). If you use unified RBAC you also need this Permission: "Email & collaboration metadata (read)" for hard delete to work.
 
   > [!NOTE]
   > In U.S. Government organizations (Microsoft 365 GCC, GCC High, and DoD) admins can take the actions **Soft delete**, **Move to junk folder**, **Move to deleted items**, **Hard delete**, and **Move to inbox**. The actions **Delete sender's copy** and **Move to inbox** from quarantine folder aren't available. Also, the action logs are available only at <https://security.microsoft.com/threatincidents>, not in the **Action Center** at <https://security.microsoft.com/action-center>.


### PR DESCRIPTION
"Email & collaboration metadata (read)" this permission is neecded if you use unified rbac  It only States its needed for view and download mail message and content but it´s definetly needed for hard delete to work. since it´s not modifier in the security portal to be required, please update documentation