### PR TITLE
Update run-advanced-query-api.md

### DIFF
--- a/defender-endpoint/api/run-advanced-query-api.md
+++ b/defender-endpoint/api/run-advanced-query-api.md
@@ -106,11 +106,7 @@ POST https://api.securitycenter.microsoft.com/api/advancedqueries/run
 
 ```json
 {
-    "Query":"DeviceProcessEvents
-|where InitiatingProcessFileName =~ 'powershell.exe'
-|where ProcessCommandLine contains 'appdata'
-|project Timestamp, FileName, InitiatingProcessFileName, DeviceId
-|limit 2"
+    "Query":"DeviceProcessEvents |where InitiatingProcessFileName =~ 'powershell.exe' |where ProcessCommandLine contains 'appdata' |project Timestamp, FileName, InitiatingProcessFileName, DeviceId |limit 2"
 }
 ```
 


### PR DESCRIPTION
With the query format given as it was, one gets an error like the one below:

{
  "error": {
    "code": "InvalidRequestBody",
    "message": "Missing query.",
    "target": "|cd9f5106-4aa2341c0de87fd0.1.2."
  }
}

Correct request body is a one liner:
{
  "Query": "DeviceProcessEvents | where InitiatingProcessFileName =~ 'powershell.exe'| where ProcessCommandLine contains 'appdata'| project Timestamp, FileName, InitiatingProcessFileName, DeviceId |limit 2"
}