### PR TITLE
Fix Typo in mdatp package name

### DIFF
--- a/defender-endpoint/linux-install-with-saltack.md
+++ b/defender-endpoint/linux-install-with-saltack.md
@@ -154,7 +154,7 @@ In this step, you create a SaltState state file in your configuration repository
    ```console
    install_mdatp_package:
      pkg.installed:
-       - name: matp
+       - name: mdatp
        - required: add_ms_repo
    ```
 


### PR DESCRIPTION
There is a typo that says matp in the example saltstate file.

I was wondering why the state was failing 😅