### PR TITLE
Update capacity-planning.md - Sizing Tool sensor scope

### DIFF
--- a/ATPDocs/deploy/capacity-planning.md
+++ b/ATPDocs/deploy/capacity-planning.md
@@ -22,7 +22,7 @@ The sizing tool measures the capacity needed for domain controllers only. There 
 
 - Download the [Defender for Identity sizing tool](<https://aka.ms/mdi/sizingtool>).
 - Review the [Defender for Identity architecture](../architecture.md) article.
-- Review the [Defender for Identity prerequisites](prerequisites-sensor-version-2.md) article.
+- Review the [Defender for Identity prerequisites](prerequisites-sensor-version-2.md) article.  The Microsoft Defender for Identity Sizing Tool currently only applies to the sensor version 2.x.
 
 To ensure accurate results, only run the sizing tool *before* you've installed any Defender for Identity sensors in your environment.
 


### PR DESCRIPTION
Updated the Prerequistes section to state that the Sizing Tool is currently only applicable to the 2.x sensor.  Engineering has not confirmed if it has been updated and tested for sensor version 3.x yet.