### PR TITLE
Update validate-antimalware.md

### DIFF
--- a/defender-endpoint/validate-antimalware.md
+++ b/defender-endpoint/validate-antimalware.md
@@ -52,7 +52,9 @@ You can run an antivirus detection test to verify that the device is properly on
    1. Copy the following string: `X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*`.
    
    2. Paste the string into a `.TXT` file and save it as `EICAR.txt`.
-            
+
+3. Open a Command Prompt and run: `type EICAR.txt`.
+
 ### Linux/macOS
 
 1. Ensure that real-time protection is enabled. Run the following command and confirm the output is `"true"`:


### PR DESCRIPTION
The documentation causes confusion with customers with regard to the detection behavior of Windows Defender as they expect an immediate detection once the file is saved. But due to perf optimizations that make this type of validation quite problematic.

Added instruction line "3. Open a Command Prompt and Run: 'type EICAR.txt' " to make the validation deterministic and reduce confusion of Cx (less IcM).