### PR TITLE
Update Safe Links API description for clarity to add Outlook Mobile s…

### DIFF
--- a/defender-office-365/safe-links-about.md
+++ b/defender-office-365/safe-links-about.md
@@ -138,7 +138,7 @@ The settings in Safe Links policies that apply to email messages are described i
       - Selected (on): Messages that contain URLs are held until scanning is finished. Messages are delivered only after the URLs are confirmed to be safe. This value is the recommended value.
       - Not selected (off): If URL scanning can't complete, deliver the message anyway.
 
-  - **Do not rewrite URLs, do checks via SafeLinks API only**: If this setting is selected (on), no URL wrapping takes place but the URLs are scanned prior to message delivery. In supported versions of Outlook (Windows, Mac, and Outlook on the web), Safe Links is called via APIs at the time of URL click for an extra scan.
+  - **Do not rewrite URLs, do checks via SafeLinks API only**: If this setting is selected (on), no URL wrapping takes place but the URLs are scanned prior to message delivery. In supported versions of Outlook (Windows, Mac, Outlook on the web, Outlook on Mobile for iOS and Android), Safe Links is called via APIs at the time of URL click for an extra scan.
 
   For more information about the recommended values for Standard and Strict policy settings for Safe Links policies, see [Safe Links policy settings](recommended-settings-for-eop-and-office365.md#safe-links-policy-settings).
 


### PR DESCRIPTION
…upport

Updated the description for the Safe Links API to include Outlook on Mobile for iOS and Android.

This work was done a while back but public doc wasn't updated:  Feature 4845661: [Prevention - URLs] - Integrate Outlook Mobile with Safelinks to protect clicks from all First party email clients