### PR TITLE
Remove link to blog post from exploit protection reference

### DIFF
--- a/defender-endpoint/exploit-protection-reference.md
+++ b/defender-endpoint/exploit-protection-reference.md
@@ -252,7 +252,7 @@ Block untrusted fonts mitigates the risk of a flaw in font parsing leading to th
 
 This mitigation is implemented within GDI, which validates the location of the file. If the file isn't in the system fonts directory, the font won't load for parsing and the call will fail.
 
-This mitigation is in addition to the built-in mitigation provided in Windows 10 1607 and later, and Windows 11, which moves font parsing out of the kernel and into a user-mode app container. Any exploit based on font parsing, as a result, happens in a sandboxed and isolated context, which reduces the risk significantly. For details on this mitigation, see the blog [Hardening Windows 10 with zero-day exploit mitigations](https://www.microsoft.com/security/blog/2017/01/13/hardening-windows-10-with-zero-day-exploit-mitigations/).
+This mitigation is in addition to the built-in mitigation provided in Windows 10 1607 and later, and Windows 11, which moves font parsing out of the kernel and into a user-mode app container. Any exploit based on font parsing, as a result, happens in a sandboxed and isolated context, which reduces the risk significantly.
 
 ### Compatibility considerations
 


### PR DESCRIPTION
[Blog entry 2017-01-13 has gone.](https://www.microsoft.com/en-us/security/blog/search/?s&paged=121)