### PR TITLE
Remove wrong message to delete mdatp_offboard file

### DIFF
--- a/defender-endpoint/linux-install-manually.md
+++ b/defender-endpoint/linux-install-manually.md
@@ -413,8 +413,7 @@ Download the onboarding package from the [Microsoft Defender portal](https://sec
 
    > [!NOTE]
    > To run this command, you must have `python` or `python3` installed on the device depending on the distro and version. If needed, see [Step-by-step Instructions for Installing Python on Linux](https://opensource.com/article/20/4/install-python-linux).
-   > 
-   > To onboard a device that was previously offboard, you must remove the mdatp_offboard.json file located at /etc/opt/microsoft/mdatp.
+   
    
    If you're running RHEL 8.x or Ubuntu 20.04 or higher, you need to use `python3`. Run the following command:
    


### PR DESCRIPTION
With the latest defender version 101.25042.0002, we do not need delete the mdatp_offboard.json file. It is automatically deleted