### PR TITLE
Update forbidden characters in live response scripts

### DIFF
--- a/defender-endpoint/live-response-command-examples.md
+++ b/defender-endpoint/live-response-command-examples.md
@@ -212,7 +212,7 @@ run get-process-by-name.ps1 -parameters "-processName Registry"
 > For long running commands such as '**run**' or '**getfile**', you might want to use the '**&**' symbol at the end of the command to perform that action in the background.
 > If you use the '**g**' symbol, you can continue investigating the machine and return to the background command when done using '**fg**' [basic command](live-response.md#basic-commands).
 >
-> When passing parameters to a live response script, don't include the following forbidden characters: **';'**, **'&'**, **'|'**, **'!'**, and **'$'**.
+> When passing parameters to a live response script, don't include the following forbidden characters: **';'**, **'&'**, **'|'**, **'!'**, **'$'**, **'('** and **')'**.
 
 ## `scheduledtask`
 


### PR DESCRIPTION
Added '(' and ')' to the list of forbidden characters for live response scripts, as the error message when running the command contains these:
```
Error: Please avoid using the following characters as part of scripts' parameters: ; & | ! $ ( )
```