### PR TITLE
Update notes on indicator precedence and conflicts

### DIFF
--- a/defender-endpoint/indicator-file.md
+++ b/defender-endpoint/indicator-file.md
@@ -190,6 +190,16 @@ Cert and File IoC policy handling conflicts follow this order:
 > [!NOTE]
 > In situations when Microsoft Defender Antivirus is set to **Block**, but Defender for Endpoint indicators for file hash or certificates are set to **Allow**, the policy defaults to **Allow**.
 
+> [!NOTE]
+> In situations where a certificate-based indicator is configured to **Block**, but a file hash indicator for one of its signed files is configured to **Allow**, this configuration is **not supported by design**. 
+> Certificate-based indicators have higher precedence in the Defender evaluation pipeline and will always override file hash allow indicators.
+
+> A configuration that simultaneously:
+> - blocks a certificate, and
+> - attempts to allow one of its signed files via file hash
+>
+> is **not supported**. Certificate-based indicators take precedence, and therefore the file will continue to be blocked.
+
 If there are conflicting file IoC policies with the same enforcement type and target, the policy of the more secure (meaning longer) hash is applied. For example, an SHA-256 file hash IoC policy takes precedence over an MD5 file hash IoC policy if both hash types define the same file.
 
 > [!WARNING]


### PR DESCRIPTION
Internal engineering review confirmed this is intended behavior. Updating documentation to reflect the unsupported certificate-block + file-hash-allow scenario.