### PR TITLE
Fix typo in SPF configuration example

### DIFF
--- a/defender-office-365/email-authentication-spf-configure.md
+++ b/defender-office-365/email-authentication-spf-configure.md
@@ -78,7 +78,7 @@ v=spf1 <valid mail sources> <enforcement rule>
 Or:
 
 ```text
-v=spf1 [<ip4>|<ip6>:<PublicIPAddress1> <ip4>|<ip6>:<PublicIPAddress2>... <ip4>|<ip6>:<PublicIPAddressN>] [include:<DomainName1> include:<DomainName1>... include:<DomainNameN>] <-all | ~all>
+v=spf1 [<ip4>|<ip6>:<PublicIPAddress1> <ip4>|<ip6>:<PublicIPAddress2>... <ip4>|<ip6>:<PublicIPAddressN>] [include:<DomainName1> include:<DomainName2>... include:<DomainNameN>] <-all | ~all>
 ```
 
 For example:


### PR DESCRIPTION
Fix duplicated domain name by renaming the second occurrence from `DomainName1` to `DomainName2`.