### PR TITLE
Update raw-data-export-event-hub.md

### DIFF
--- a/defender-endpoint/api/raw-data-export-event-hub.md
+++ b/defender-endpoint/api/raw-data-export-event-hub.md
@@ -83,9 +83,11 @@ appliesto:
 - For more information about the schema of Microsoft Defender for Endpoint events, see [Advanced Hunting overview](/defender-xdr/advanced-hunting-overview).
 
 - In Advanced Hunting, the **DeviceInfo** table has a column named **MachineGroup** which contains the group of the device. Here, every event is decorated with this column as well. For more information, see [Device Groups](../machine-groups.md).
+
     > [!NOTE]
     > Device group creation is supported in Defender for Endpoint Plan 1 and Plan 2.
-    > Please note that the data size transferred to Event Hubs may exceed the size estimated using estimate_data_size() from Advanced Hunting in the Microsoft Defender portal.
+    > 
+    > The data transferred to Event Hubs might exceed the size estimated using `estimate_data_size()` from Advanced Hunting in the Microsoft Defender portal.
 
 ## Data types mapping
 

--- a/defender-endpoint/api/raw-data-export-event-hub.md
+++ b/defender-endpoint/api/raw-data-export-event-hub.md
@@ -85,6 +85,7 @@ appliesto:
 - In Advanced Hunting, the **DeviceInfo** table has a column named **MachineGroup** which contains the group of the device. Here, every event is decorated with this column as well. For more information, see [Device Groups](../machine-groups.md).
     > [!NOTE]
     > Device group creation is supported in Defender for Endpoint Plan 1 and Plan 2.
+    > Please note that the data size transferred to Event Hubs may exceed the size estimated using estimate_data_size() from Advanced Hunting in the Microsoft Defender portal.
 
 ## Data types mapping
 


### PR DESCRIPTION
My customer is using streaming API to send AH query data to Event Hubs. Then, the customer caluculated the data size of AH data on Defender portal using "estimate_data_size() ", the result was eg 500MB. However, the customer looks at the "incoming bytes" on Event hubs showing around 1.0GB. The size will be difference between AH data size and Event Hub data size basically. The customer strongly give us a request to see the information before the customer start to use Event Hubs. So, I would like to add the comments on this document for publishing this notes.