### PR TITLE
Update WSL device ID queries to use isnotempty

### DIFF
--- a/defender-endpoint/mde-plugin-wsl.md
+++ b/defender-endpoint/mde-plugin-wsl.md
@@ -222,9 +222,8 @@ In the Advanced Hunting schema, under the `DeviceInfo` table, there's a new attr
 ```kusto
 //Get all WSL device ids for the current organization/tenant 
 let wsl_endpoints = DeviceInfo  
-| where OSPlatform == "Linux" and isempty(HostDeviceId) != true
+| where OSPlatform == "Linux" and isnotempty(HostDeviceId)
 | distinct DeviceId; 
-
 wsl_endpoints
 ```
 
@@ -233,7 +232,7 @@ wsl_endpoints
 ```kusto
 //Get WSL device ids and their corresponding host device ids 
 DeviceInfo  
-| where OSPlatform == "Linux" and isempty(HostDeviceId) != true
+| where OSPlatform == "Linux" and isnotempty(HostDeviceId)
 | distinct WSLDeviceId=DeviceId, HostDeviceId
 ```
 
@@ -242,9 +241,8 @@ DeviceInfo
 ```kusto
 //Get a list of WSL device ids where curl or wget was run
 let wsl_endpoints = DeviceInfo  
-| where OSPlatform == "Linux" and isempty(HostDeviceId) != true
+| where OSPlatform == "Linux" and isnotempty(HostDeviceId)
 | distinct DeviceId; 
-
 DeviceProcessEvents   
 | where FileName == "curl" or FileName == "wget" 
 | where DeviceId in (wsl_endpoints) 


### PR DESCRIPTION
Optimised the KQL example to use "isnotempty" instead of "isempty != true", which is less clunky.