### PR TITLE
Remove duplicate Debian 13 instructions from linux-install-manually.md

### DIFF
--- a/defender-endpoint/linux-install-manually.md
+++ b/defender-endpoint/linux-install-manually.md
@@ -230,12 +230,6 @@ In order to preview new features and provide early feedback, it's recommended th
       sudo chmod o+r /usr/share/keyrings/microsoft-prod.gpg
       ```
       
-   - For Debian 13 and later, run the following command.
-
-      ```bash
-      curl -sSL https://packages.microsoft.com/keys/microsoft-2025.asc | gpg --dearmor | sudo tee /usr/share/keyrings/microsoft-prod.gpg > /dev/null
-      ```
-
 7. Install the HTTPS driver if not already installed:
 
    ```bash


### PR DESCRIPTION
This PR removes duplicated Debian 13 installation instructions from linux-install-manually.md.
The content was added twice, which could cause confusion for readers. This change keeps a single, correct set of instructions to improve clarity and maintainability of the documentation.