### PR TITLE
Revise permissions for email spoofing configuration

### DIFF
--- a/defender-office-365/tenant-allow-block-list-email-spoof-configure.md
+++ b/defender-office-365/tenant-allow-block-list-email-spoof-configure.md
@@ -60,7 +60,7 @@ This article describes how admins can manage entries for email senders in the Mi
 - An entry should be active within 5 minutes.
 
 - You need to be assigned permissions before you can do the procedures in this article. You have the following options:
-  - [Microsoft Defender XDR Unified role based access control (RBAC)](/defender-xdr/manage-rbac) (If **Email & collaboration** \> **Defender for Office 365** permissions is :::image type="icon" source="media/scc-toggle-on.png" border="false"::: **Active**. Affects the Defender portal only, not PowerShell):
+  - [Microsoft Defender XDR Unified role based access control (RBAC)](/defender-xdr/manage-rbac) (If **Email & collaboration** \> **Defender for Office 365** and **Email & collaboration** \> **Exchange Online permissions** are both :::image type="icon" source="media/scc-toggle-on.png" border="false"::: **Active**. Affects the Defender portal only, not PowerShell):
     - *Add and remove entries from the Tenant Allow/Block List*: Membership assigned with the following permissions:
       - **Authorization and settings/Security settings/Detection tuning (manage)**
     - *Read-only access to the Tenant Allow/Block List*:


### PR DESCRIPTION
Updated permissions requirements for configuring email spoofing settings to include Exchange Online permissions as it was uncovered via an ICM that this is also required.