### PR TITLE
Add note clarifying multi-message and email thread reporting behavior

### DIFF
--- a/defender-office-365/submissions-users-report-message-add-in-configure.md
+++ b/defender-office-365/submissions-users-report-message-add-in-configure.md
@@ -7,7 +7,7 @@ ms.author: chrisda
 audience: Admin
 ms.reviewer: dhagarwal
 ms.topic: how-to
-ms.date: 10/06/2025
+ms.date: 04/07/2026
 ms.localizationpriority: medium
 search.appverid:
   - MET150
@@ -35,6 +35,9 @@ The built-in **Report** button in [supported versions of Outlook](submissions-ou
 
 Microsoft uses these user reported messages to improve the effectiveness of email protection technologies. For example, suppose people are reporting many messages as phishing using the **Report** button. This information surfaces in the Security Dashboard and other reports. This information probably indicates the anti-phishing policies in your organization need to be updated.
 
+> [!NOTE]
+> When reporting multiple messages or an email thread (conversation) using the built-in **Report** button, each message is submitted as a **separate, individual report** with its own sender, subject, and timestamp.
+
 The following table describes the advantages of the built-in **Report** button over the Report Message and Report Phishing add-ins:
 
 |Benefits|Built-in Report button|Report add-ins|
@@ -55,9 +58,6 @@ The following table describes the advantages of the built-in **Report** button o
 |Works flawlessly with firewalls|:::image type="icon" source="media/feature_present_icon.png":::|:::image type="icon" source="media/feature_absent_icon.png":::|
 
 <sup>\*</sup>User reporting from shared and delegate mailboxes is available in [select supported clients](submissions-outlook-report-messages.md#use-the-built-in-report-button-in-outlook).
-
-> [!NOTE]
-> When reporting multiple messages or an email thread (conversation) using the built-in **Report** button, each email is submitted as a **separate, individual report** with its own sender, subject, and timestamp.
 
 The rest of this article describes how to remove the Report Message and Report Phishing add-ins.
 

--- a/defender-office-365/submissions-users-report-message-add-in-configure.md
+++ b/defender-office-365/submissions-users-report-message-add-in-configure.md
@@ -56,6 +56,9 @@ The following table describes the advantages of the built-in **Report** button o
 
 <sup>\*</sup>User reporting from shared and delegate mailboxes is available in [select supported clients](submissions-outlook-report-messages.md#use-the-built-in-report-button-in-outlook).
 
+> [!NOTE]
+> When reporting multiple messages or an email thread (conversation) using the built-in **Report** button, each email is submitted as a **separate, individual report** with its own sender, subject, and timestamp.
+
 The rest of this article describes how to remove the Report Message and Report Phishing add-ins.
 
 ## What do you need to know before you begin?


### PR DESCRIPTION
Adds a NOTE to the Report Message add-in configuration page clarifying that when users report multiple messages or an email thread using the built-in Report button, each email is submitted as a separate individual report. Related: ADO Work Item 6911081