### PR TITLE
Add support for SUSE Linux Enterprise Server 16.x

### DIFF
--- a/defender-endpoint/mde-linux-prerequisites.md
+++ b/defender-endpoint/mde-linux-prerequisites.md
@@ -103,7 +103,7 @@ The following Linux server distributions are supported:
 | Ubuntu LTS | 16.04, 18.04, 20.04, 22.04,24.04 | 20.04, 22.04, 24.04 |
 | Ubuntu Pro | 22.04, 24.04 | 22.04, 24.04 |
 | Debian | 9–13 | 11, 12, 13 |
-| SUSE Linux Enterprise Server | 12.x, 15.x | 15 (SP5, SP6) |
+| SUSE Linux Enterprise Server | 12.x, 15.x, 16.x | 15 (SP5, SP6) |
 | Oracle Linux | 7.2+, 8.x, 9.x | 8.x, 9.x |
 | Amazon Linux | 2, 2023 | 2, 2023 |
 | Fedora | 33–42 | - |


### PR DESCRIPTION
 SUSE 16 image has been officially released and is supported in the Azure Marketplace, could you please confirm whether Microsoft Defender has been tested and validated for SUSE 16 as well? And this PR can be merged accordingly. 
https://learn.microsoft.com/en-us/azure/virtual-machines/linux/endorsed-distros#platform-image-partners