### PR TITLE
Update configure-contextual-file-folder-exclusions-microsoft-defender…

### DIFF
--- a/defender-endpoint/configure-contextual-file-folder-exclusions-microsoft-defender-antivirus.md
+++ b/defender-endpoint/configure-contextual-file-folder-exclusions-microsoft-defender-antivirus.md
@@ -98,6 +98,7 @@ If you don't specify any other options, the file/folder is excluded from all typ
 
 > [!NOTE]  
 > Wildcards are supported in file/folder exclusions.
+> A backslash(\) is required before the colon(:) and after a file extension in order to have the exclusions apply successfully.
 
 #### Folders
 

--- a/defender-endpoint/configure-contextual-file-folder-exclusions-microsoft-defender-antivirus.md
+++ b/defender-endpoint/configure-contextual-file-folder-exclusions-microsoft-defender-antivirus.md
@@ -98,7 +98,8 @@ If you don't specify any other options, the file/folder is excluded from all typ
 
 > [!NOTE]  
 > Wildcards are supported in file/folder exclusions.
-> A backslash(\) is required before the colon(:) and after a file extension in order to have the exclusions apply successfully.
+>
+> A backslash (\) is required before the colon (:) and after a file extension.
 
 #### Folders
 


### PR DESCRIPTION
…-antivirus.md

Note: A backslash(\) is required before the colon(:) and after a file extension in order to have the exclusions apply successfully.