### PR TITLE
Update configure-contextual-file-folder-exclusions-microsoft-defender…

### DIFF
--- a/defender-endpoint/configure-contextual-file-folder-exclusions-microsoft-defender-antivirus.md
+++ b/defender-endpoint/configure-contextual-file-folder-exclusions-microsoft-defender-antivirus.md
@@ -99,7 +99,7 @@ If you don't specify any other options, the file/folder is excluded from all typ
 > [!NOTE]  
 > Wildcards are supported in file/folder exclusions.
 >
-> A backslash (\) is required before the colon (:) and after a file extension.
+> A backslash ( \ ) is required before the colon ( : ) and after a file extension.
 
 #### Folders
 


### PR DESCRIPTION
…-antivirus.md

the \ disappeared in the initial change made. see screenshot
<img width="908" height="205" alt="Screenshot 2026-04-28 123100" src="https://github.com/user-attachments/assets/0bde9efc-ba2c-45fd-a8e6-3c00d7159012" />
