### PR TITLE
Add Windows Server 2025 sensor known issue

### DIFF
--- a/defender-for-identity/deploy/deploy-sensor-v3.md
+++ b/defender-for-identity/deploy/deploy-sensor-v3.md
@@ -34,7 +34,7 @@ Make sure that the server on which you're activating the sensor:
 - Includes the [March 2026 or later](https://support.microsoft.com/en-us/topic/march-10-2026-kb5078766-os-build-20348-4893-fa3ee26a-0877-47d7-a4b2-9dd632ea8cea) cumulative update.
 
 > [!IMPORTANT]
-> Migrating domain controllers running Windows Server 2025 to sensor v3.x isn’t currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor. Full v3.x support is planned for July 2026.
+> Migrating domain controllers running Windows Server 2025 to sensor v3.x isn’t currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor.
 
 #### Supported server types
 

--- a/defender-for-identity/deploy/deploy-sensor-v3.md
+++ b/defender-for-identity/deploy/deploy-sensor-v3.md
@@ -33,8 +33,8 @@ Make sure that the server on which you're activating the sensor:
 - Is running Windows Server 2019 or later.
 - Includes the [March 2026 or later](https://support.microsoft.com/en-us/topic/march-10-2026-kb5078766-os-build-20348-4893-fa3ee26a-0877-47d7-a4b2-9dd632ea8cea) cumulative update.
 
-> [!NOTE]
-> Defender for Identity sensors on Windows Server 2025 are temporarily running an older version and may not include the latest detection improvements. An automatic update is planned for July 2026. No action is required.
+> [!IMPORTANT]
+> Migrating domain controllers running Windows Server 2025 to sensor v3.x isn’t currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor. Full v3.x support is planned for July 2026.
 
 #### Supported server types
 

--- a/defender-for-identity/deploy/deploy-sensor-v3.md
+++ b/defender-for-identity/deploy/deploy-sensor-v3.md
@@ -33,6 +33,9 @@ Make sure that the server on which you're activating the sensor:
 - Is running Windows Server 2019 or later.
 - Includes the [March 2026 or later](https://support.microsoft.com/en-us/topic/march-10-2026-kb5078766-os-build-20348-4893-fa3ee26a-0877-47d7-a4b2-9dd632ea8cea) cumulative update.
 
+> [!NOTE]
+> Defender for Identity sensors on Windows Server 2025 are temporarily running an older version and may not include the latest detection improvements. An automatic update is planned for July 2026. No action is required.
+
 #### Supported server types
 
 The v3.x sensor supports domain controllers, including domain controllers with these identity roles:

--- a/defender-for-identity/troubleshooting-known-issues.md
+++ b/defender-for-identity/troubleshooting-known-issues.md
@@ -490,13 +490,17 @@ In some v3 sensor environments, auditing health alerts might persist even when W
 
 Defender for Identity sensors (v3.x) installed on Windows Server 2025 are currently running an older sensor version and don't include the latest detection and feature improvements available on other operating systems.
 
+### Cause
+
+A servicing change affected the update delivery path for Windows Server 2025. Updates that were delivered to other operating systems were not applied to Windows Server 2025.
+
 ### Impact
 
 Sensors on Windows Server 2025 are missing some newer detection capabilities. Your environment remains protected, and no security vulnerabilities are introduced by this issue.
 
 ### Resolution
 
-An automatic update is planned for July 2026. Once available, sensors on Windows Server 2025 will update automatically — no action is needed from your side.
+An automatic update is planned for July 2026. Once available, sensors on Windows Server 2025 will update automatically — no action is required.
 
 ## Next steps
 

--- a/defender-for-identity/troubleshooting-known-issues.md
+++ b/defender-for-identity/troubleshooting-known-issues.md
@@ -486,6 +486,18 @@ If permissions need to be reconfigured, follow the steps outlined in this [guide
 
 In some v3 sensor environments, auditing health alerts might persist even when Windows auditing is correctly configured. This primarily occurs with manual auditing configuration, such as using Group Policy or PowerShell. The sensor remains healthy and detections aren't affected. To resolve, enable **Automatic Windows auditing configuration** in the Defender for Identity portal under **Settings** > **Advanced features**.
 
+## Windows Server 2025 sensors running an older version
+
+Defender for Identity sensors (v3.x) installed on Windows Server 2025 are currently running an older sensor version and don't include the latest detection and feature improvements available on other operating systems.
+
+### Impact
+
+Sensors on Windows Server 2025 are missing some newer detection capabilities. Your environment remains protected, and no security vulnerabilities are introduced by this issue.
+
+### Resolution
+
+An automatic update is planned for July 2026. Once available, sensors on Windows Server 2025 will update automatically — no action is needed from your side.
+
 ## Next steps
 
 - [Defender for Identity sensor v2.x prerequisites](deploy/prerequisites-sensor-version-2.md) and [Defender for Identity sensor v3.x prerequisites](deploy/deploy-sensor-v3.md) 

--- a/defender-for-identity/troubleshooting-known-issues.md
+++ b/defender-for-identity/troubleshooting-known-issues.md
@@ -496,7 +496,7 @@ A servicing branch change affected the update delivery path for Windows Server 2
 
 ### Resolution
 
-Full sensor v3.x support for Windows Server 2025 is planned for July 2026. Until then, the v2.x sensor continues to protect Windows Server 2025 domain controllers with no action required.
+No action is required. The v2.x sensor continues to protect Windows Server 2025 domain controllers. This page will be updated when full v3.x support becomes available.
 
 ## Next steps
 

--- a/defender-for-identity/troubleshooting-known-issues.md
+++ b/defender-for-identity/troubleshooting-known-issues.md
@@ -486,21 +486,17 @@ If permissions need to be reconfigured, follow the steps outlined in this [guide
 
 In some v3 sensor environments, auditing health alerts might persist even when Windows auditing is correctly configured. This primarily occurs with manual auditing configuration, such as using Group Policy or PowerShell. The sensor remains healthy and detections aren't affected. To resolve, enable **Automatic Windows auditing configuration** in the Defender for Identity portal under **Settings** > **Advanced features**.
 
-## Windows Server 2025 sensors running an older version
+## Windows Server 2025 sensor v3.x migration not supported
 
-Defender for Identity sensors (v3.x) installed on Windows Server 2025 are currently running an older sensor version and don't include the latest detection and feature improvements available on other operating systems.
+Migrating domain controllers running Windows Server 2025 to sensor v3.x isn't currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor until full v3.x support is available.
 
 ### Cause
 
-A servicing change affected the update delivery path for Windows Server 2025. Updates that were delivered to other operating systems were not applied to Windows Server 2025.
-
-### Impact
-
-Sensors on Windows Server 2025 are missing some newer detection capabilities. Your environment remains protected, and no security vulnerabilities are introduced by this issue.
+A servicing branch change affected the update delivery path for Windows Server 2025. The sensor v3.x components required for migration haven't been backported to this platform yet.
 
 ### Resolution
 
-An automatic update is planned for July 2026. Once available, sensors on Windows Server 2025 will update automatically — no action is required.
+Full sensor v3.x support for Windows Server 2025 is planned for July 2026. Until then, the v2.x sensor continues to protect Windows Server 2025 domain controllers with no action required.
 
 ## Next steps
 

--- a/defender-for-identity/troubleshooting-known-issues.md
+++ b/defender-for-identity/troubleshooting-known-issues.md
@@ -490,14 +490,6 @@ In some v3 sensor environments, auditing health alerts might persist even when W
 
 Migrating domain controllers running Windows Server 2025 to sensor v3.x isn't currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor until full v3.x support is available.
 
-### Cause
-
-A servicing branch change affected the update delivery path for Windows Server 2025. The sensor v3.x components required for migration haven't been backported to this platform yet.
-
-### Resolution
-
-No action is required. The v2.x sensor continues to protect Windows Server 2025 domain controllers. This page will be updated when full v3.x support becomes available.
-
 ## Next steps
 
 - [Defender for Identity sensor v2.x prerequisites](deploy/prerequisites-sensor-version-2.md) and [Defender for Identity sensor v3.x prerequisites](deploy/deploy-sensor-v3.md) 

--- a/defender-for-identity/whats-new.md
+++ b/defender-for-identity/whats-new.md
@@ -46,11 +46,11 @@ These new alerts were added to the Defender for Identity security alerts:
 - [Suspected Conditional Access bypass via non-compliant device](alerts-xdr.md#suspected-conditional-access-bypass-via-non-compliant-device)
 - [Suspicious addition of default third‑party MFA method to user account](alerts-xdr.md#suspicious-addition-of-default-thirdparty-mfa-method-to-user-account)
 
-### Known issue: Windows Server 2025 sensors running an older version
+### Known limitation: Windows Server 2025 sensor v3.x migration not supported
 
-Defender for Identity sensors (v3.x) on Windows Server 2025 are currently running an older sensor version and don't include the latest detection and feature improvements. This issue will be resolved automatically with an upcoming update planned for July 2026. No action is required from customers.
+Migrating domain controllers running Windows Server 2025 to sensor v3.x isn't currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor until full v3.x support is available in July 2026.
 
-For more information, see [Windows Server 2025 sensors running an older version](troubleshooting-known-issues.md#windows-server-2025-sensors-running-an-older-version).
+For more information, see [Windows Server 2025 sensor v3.x migration not supported](troubleshooting-known-issues.md#windows-server-2025-sensor-v3x-migration-not-supported).
 
 ## April 2026
 

--- a/defender-for-identity/whats-new.md
+++ b/defender-for-identity/whats-new.md
@@ -48,7 +48,7 @@ These new alerts were added to the Defender for Identity security alerts:
 
 ### Known limitation: Windows Server 2025 sensor v3.x migration not supported
 
-Migrating domain controllers running Windows Server 2025 to sensor v3.x isn't currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor until full v3.x support is available in July 2026.
+Migrating domain controllers running Windows Server 2025 to sensor v3.x isn't currently supported. Windows Server 2025 domain controllers should continue using the v2.x sensor.
 
 For more information, see [Windows Server 2025 sensor v3.x migration not supported](troubleshooting-known-issues.md#windows-server-2025-sensor-v3x-migration-not-supported).
 

--- a/defender-for-identity/whats-new.md
+++ b/defender-for-identity/whats-new.md
@@ -46,6 +46,12 @@ These new alerts were added to the Defender for Identity security alerts:
 - [Suspected Conditional Access bypass via non-compliant device](alerts-xdr.md#suspected-conditional-access-bypass-via-non-compliant-device)
 - [Suspicious addition of default third‑party MFA method to user account](alerts-xdr.md#suspicious-addition-of-default-thirdparty-mfa-method-to-user-account)
 
+### Known issue: Windows Server 2025 sensors running an older version
+
+Defender for Identity sensors (v3.x) on Windows Server 2025 are currently running an older sensor version and don't include the latest detection and feature improvements. This issue will be resolved automatically with an upcoming update planned for July 2026. No action is required from customers.
+
+For more information, see [Windows Server 2025 sensors running an older version](troubleshooting-known-issues.md#windows-server-2025-sensors-running-an-older-version).
+
 ## April 2026
 
 ### **Identity Explorer (Preview)**


### PR DESCRIPTION
Documents a known issue where Defender for Identity sensors on Windows Server 2025 are running an older version. Adds entries to what's-new, troubleshooting-known-issues, and deploy-sensor-v3 pages. Automatic fix planned for July 2026.