### PR TITLE
 Add performance profiles configuration documentation for macOS

### DIFF
--- a/defender-endpoint/mac-preferences.md
+++ b/defender-endpoint/mac-preferences.md
@@ -990,6 +990,21 @@ The following templates contain entries for all settings described in this docum
         <key>userInitiatedFeedback</key>
         <string>enabled</string>
     </dict>
+    <key>features</key>
+    <dict>
+        <key>performanceProfiles</key>
+        <string>enabled</string>
+    </dict>
+    <key>performanceProfiles</key>
+    <dict>
+        <key>merge_policy</key>
+        <string>merge</string>
+        <key>profiles</key>
+        <array>
+            <string>profile1</string>
+            <string>profile2</string>
+        </array>
+    </dict>
 </dict>
 </plist>
 ```
@@ -1181,6 +1196,21 @@ The following templates contain entries for all settings described in this docum
                     <false/>
                     <key>userInitiatedFeedback</key>
                     <string>enabled</string>
+                </dict>
+                <key>features</key>
+                <dict>
+                    <key>performanceProfiles</key>
+                    <string>enabled</string>
+                </dict>
+                <key>performanceProfiles</key>
+                <dict>
+                    <key>merge_policy</key>
+                    <string>merge</string>
+                    <key>profiles</key>
+                    <array>
+                        <string>profile1</string>
+                        <string>profile2</string>
+                    </array>
                 </dict>
             </dict>
         </array>

--- a/defender-endpoint/mac-preferences.md
+++ b/defender-endpoint/mac-preferences.md
@@ -637,6 +637,61 @@ Used in combination with other parameters to identify the process.
 |**Data type**|Array of strings|
 |**Comments**| If specified, process argument must match those arguments exactly, case-sensitive |
 
+### Feature flags
+
+The *features* section of the configuration profile is used to enable or disable specific features of Microsoft Defender for Endpoint.
+
+|Section|Value|
+|---|---|
+|**Domain**|`com.microsoft.wdav`|
+|**Key**|features|
+|**Data type**|Dictionary (nested preference)|
+|**Comments**|See the following sections for a description of the dictionary contents.|
+
+#### Enable / disable performance profiles
+
+Specify whether the performance profiles feature is enabled on the device.
+
+|Section|Value|
+|---|---|
+|**Domain**|`com.microsoft.wdav`|
+|**Key**|performanceProfiles|
+|**Data type**|String|
+|**Possible values**|enabled <p> disabled (default)|
+
+### Performance profiles
+
+The *performanceProfiles* section of the configuration profile is used to specify which performance profiles are applied and how they merge with locally defined settings.
+
+|Section|Value|
+|---|---|
+|**Domain**|`com.microsoft.wdav`|
+|**Key**|performanceProfiles|
+|**Data type**|Dictionary (nested preference)|
+|**Comments**|See the following sections for a description of the dictionary contents.|
+
+#### Merge policy for performance profiles
+
+Specify the merge policy for performance profiles. This can be a combination of administrator-defined and user-defined profiles (`merge`), or only administrator-defined profiles (`admin_only`).
+
+|Section|Value|
+|---|---|
+|**Domain**|`com.microsoft.wdav`|
+|**Key**|merge_policy|
+|**Data type**|String|
+|**Possible values**|merge (default) <p> admin_only|
+
+#### Profiles
+
+Specify the list of performance profiles to apply.
+
+|Section|Value|
+|---|---|
+|**Domain**|`com.microsoft.wdav`|
+|**Key**|profiles|
+|**Data type**|Array of strings|
+|**Comments**|Specify the names of the performance profiles to enable.|
+
 ## Recommended configuration profile
 
 To get started, we recommend the following configuration for your enterprise to take advantage of all protection features that Microsoft Defender for Endpoint provides.


### PR DESCRIPTION
This PR adds documentation for the performance profiles feature in the macOS preferences reference (mac-preferences.md).

Changes
Feature flags section — Documents the features key and its performanceProfiles child for enabling/disabling performance profiles on macOS devices.
Performance profiles section — Documents the performanceProfiles configuration key, including merge_policy (merge vs. admin_only) and the profiles array.
Full profile examples — Adds features and performanceProfiles entries to both the JAMF and Intune full configuration profile XML templates.