### PR TITLE
Update CEF duplication filter for AMA 1.41 parsing change

### DIFF
--- a/sentinel/cef-syslog-ama-overview.md
+++ b/sentinel/cef-syslog-ama-overview.md
@@ -114,9 +114,12 @@ To avoid this scenario, use one of these methods:
 
 - **If changing the facility for the source appliance isn't applicable**: After you create the DCR, add ingestion time transformation to filter out CEF messages from the Syslog stream to avoid duplication. See [Tutorial: Edit a data collection rule (DCR)](/azure/azure-monitor/essentials/data-collection-rule-edit). Add KQL transformation similar to the following example:
 
-    ```json
-    "transformKql": "  source\n    |  where ProcessName !contains \"CEF\"\n"
-    ```
+> [!NOTE]
+  Starting with AMA version 1.41, the `ProcessName` field might not reliably contain "CEF" for messages from vendors that don't comply with RFC 3164/RFC 5424 syslog header format. To ensure CEF messages are properly filtered, check both `ProcessName` and `SyslogMessage`.
+ 
+     ```json
+     "transformKql": "  source\n    |  where ProcessName !contains \"CEF\" and SyslogMessage !contains \"CEF:0\"\n"
+     ```
  
 ## Next steps
 

--- a/sentinel/cef-syslog-ama-overview.md
+++ b/sentinel/cef-syslog-ama-overview.md
@@ -114,12 +114,12 @@ To avoid this scenario, use one of these methods:
 
 - **If changing the facility for the source appliance isn't applicable**: After you create the DCR, add ingestion time transformation to filter out CEF messages from the Syslog stream to avoid duplication. See [Tutorial: Edit a data collection rule (DCR)](/azure/azure-monitor/essentials/data-collection-rule-edit). Add KQL transformation similar to the following example:
 
-> [!NOTE]
-  Starting with AMA version 1.41, the `ProcessName` field might not reliably contain "CEF" for messages from vendors that don't comply with RFC 3164/RFC 5424 syslog header format. To ensure CEF messages are properly filtered, check both `ProcessName` and `SyslogMessage`.
- 
-     ```json
-     "transformKql": "  source\n    |  where ProcessName !contains \"CEF\" and SyslogMessage !contains \"CEF:0\"\n"
-     ```
+    > [!NOTE]
+    > Starting with AMA version 1.41, the `ProcessName` field might not reliably contain "CEF" for messages from vendors that don't comply with RFC 3164/RFC 5424 syslog header format. To ensure CEF messages are properly filtered, check both `ProcessName` and `SyslogMessage`.
+
+    ```json
+    "transformKql": "  source\n    |  where ProcessName !contains \"CEF\" and SyslogMessage !contains \"CEF:0\"\n"
+    ```
  
 ## Next steps
 


### PR DESCRIPTION
AMA 1.41 moved CEF-specific message cleanup from the generic syslog parser to a CEF-only pipeline stage. As a result, the ProcessName field no longer reliably contains "CEF" for messages from vendors that don't comply with RFC 3164/RFC 5424 syslog header format. This update adds a SyslogMessage check to the recommended KQL duplication avoidance transform and includes a note explaining why both checks are now required. Aligns with AMA 1.41 release notes update published by the Azure Monitor Agent team.