### PR TITLE
Fix attack disruption docs: simplify TOC title and table entries

### DIFF
--- a/defender-xdr/TOC.yml
+++ b/defender-xdr/TOC.yml
@@ -154,7 +154,7 @@
           href: m365d-autoir-results.md
         - name: Address false positives and negatives
           href: m365d-autoir-report-false-positives-negatives.md
-      - name: Attack disruption with Microsoft Sentinel
+      - name: Attack disruption
         items:
         - name: Overview
           href: automatic-attack-disruption.md

--- a/defender-xdr/automatic-attack-disruption.md
+++ b/defender-xdr/automatic-attack-disruption.md
@@ -113,8 +113,8 @@ Use the following table to find where each supported identity service is configu
 | Identity service | Availability | Configuration and setup |
 | --- | --- | --- |
 | Microsoft Entra ID and Active Directory | Generally available | [Configure automatic attack disruption in Microsoft Defender XDR](configure-attack-disruption.md) |
-| Okta (through Microsoft Sentinel integration) | Preview | [Enable attack disruption actions in Okta](okta-attack-disruption.md) |
-| AWS IAM (through Microsoft Sentinel integration) | Preview | [Enable attack disruption actions on AWS with Microsoft Sentinel](/azure/sentinel/aws-disruption?toc=/defender-xdr/toc.json&bc=/defender-xdr/breadcrumb/toc.json) |
+| Okta | Preview | [Enable attack disruption actions in Okta with Microsoft Sentinel](okta-attack-disruption.md) |
+| AWS IAM | Preview | [Enable attack disruption actions on AWS with Microsoft Sentinel](/azure/sentinel/aws-disruption?toc=/defender-xdr/toc.json&bc=/defender-xdr/breadcrumb/toc.json) |
 
 ## Identify when an attack disruption happens in your environment
 


### PR DESCRIPTION
- Shorten TOC entry from 'Attack disruption with Microsoft Sentinel' to 'Attack disruption'
- Remove redundant '(through Microsoft Sentinel integration)' from Okta and AWS IAM identity service names
- Move Microsoft Sentinel mention to Okta link text for clarity