### PR TITLE
Clarify prerequisites for attack disruption exclusions based on Unified RBAC state

### DIFF
--- a/defender-xdr/automatic-attack-disruption-exclusions.md
+++ b/defender-xdr/automatic-attack-disruption-exclusions.md
@@ -54,7 +54,7 @@ For more information, see [Activate Microsoft Defender XDR Unified RBAC](activat
 
 ## Exclusion types and approaches
 
-You can [exclude specific assets](#exclude-assets), or you can configure [broad policy-driven rules](#policy-applications-and-exclusions) based on your operational needs.
+You can [exclude specific assets](#exclude-assets), or you can configure [broad policy-driven rules](#policy-applications-and-exclusions-preview) based on your operational needs.
 
 ### Exclude assets
 

--- a/defender-xdr/automatic-attack-disruption-exclusions.md
+++ b/defender-xdr/automatic-attack-disruption-exclusions.md
@@ -11,7 +11,7 @@ ms.collection:
   - usx-security
   - usx-security
 ms.topic: how-to
-ms.date: 05/12/2025
+ms.date: 06/23/2025
 appliesto:
 - Microsoft Defender XDR
 
@@ -31,11 +31,26 @@ Automatic attack disruption and exclusion policies work together to help contain
 
 ## Prerequisites
 
-To configure automated response settings or to add or edit device tags, you must be a **Security Administrator or higher** in either [Microsoft Entra ID](https://portal.azure.com) or in the [Microsoft 365 admin center](https://admin.microsoft.com).
+The permissions required to manage attack disruption exclusions depend on whether [Microsoft Defender XDR Unified role-based access control (RBAC)](manage-rbac.md) is enabled for the relevant workload.
 
-A Security Reader and view tags but not edit them.
+### Device exclusions (endpoints)
 
-A Security operator can trigger manual incestigations but can't change automation settings.
+| Unified RBAC for endpoints | Required permission |
+| --- | --- |
+| **Disabled** | Security Administrator or Global Administrator role in [Microsoft Entra ID](https://portal.azure.com) or the [Microsoft 365 admin center](https://admin.microsoft.com). |
+| **Enabled** | Security Operator (or higher) global Microsoft Entra role, **or** the [Core security settings (manage)](custom-permissions-details.md) permission in Unified RBAC. |
+
+For more information, see [Activate Microsoft Defender XDR Unified RBAC](activate-defender-rbac.md).
+
+### Identity exclusions
+
+| Unified RBAC for identities or endpoints | Required permission |
+| --- | --- |
+| **Disabled** (both identities and endpoints) | Security Administrator or Global Administrator role in [Microsoft Entra ID](https://portal.azure.com) or the [Microsoft 365 admin center](https://admin.microsoft.com). |
+| **Enabled** (for identities or endpoints) | Security Operator (or higher) global Microsoft Entra role, **or** the [Core security settings (manage)](custom-permissions-details.md) permission in Unified RBAC. |
+
+> [!NOTE]
+> A Security Reader can view exclusions and tags but can't edit them.
 
 ## Exclusion types and approaches
 


### PR DESCRIPTION
## Summary

The prerequisites section in the attack disruption exclusions doc was inaccurate — it stated that Security Administrator or higher is always required, but this depends on whether Unified RBAC is enabled.

## Changes

- Split Prerequisites into **Device exclusions (endpoints)** and **Identity exclusions** subsections
- Added tables showing required permissions when Unified RBAC is enabled vs. disabled
- When URBAC is disabled for endpoints: Security Administrator required
- When URBAC is enabled: Security Operator or Core security settings (manage) permission is sufficient
- For identities: enabling URBAC for either identities or endpoints grants Security Operators access
- Added cross-links to Unified RBAC activation and custom permissions docs
- Retained Security Reader note

## Context

Customers were confused about required permissions in mixed Unified RBAC deployments. A recent ICM highlighted this issue.