### PR TITLE
Revert required permissions in List machines API

### DIFF
--- a/defender-endpoint/api/get-machines.md
+++ b/defender-endpoint/api/get-machines.md
@@ -61,7 +61,9 @@ Responses include only devices that the user has access to, based on device grou
 
 |Permission type|Permission|Permission display name|
 |---|---|---|
+|Application|Machine.Read.All|'Read all machine profiles'|
 |Application|Machine.ReadWrite.All|'Read and write all machine information'|
+|Delegated (work or school account)|Machine.Read|'Read machine information'|
 |Delegated (work or school account)|Machine.ReadWrite|'Read and write machine information'|
 
 ## HTTP request


### PR DESCRIPTION
## TLDR
Reverts only the **required permissions** change made to `get-machines.md` in commit 099b32f. Restores the two permission rows that were removed.

## In Depth
- **Problem:** Commit 099b32f (`remove related article links`) also dropped two valid application/delegated permissions from the List machines API permissions table.
- **Fix:** Re-add the removed rows so the documented required permissions match the API's actual supported permissions.

## Restored rows
| Permission type | Permission | Display name |
|---|---|---|
| Application | Machine.Read.All | 'Read all machine profiles' |
| Delegated (work or school account) | Machine.Read | 'Read machine information' |

Only the permissions table is changed; the prose/wording changes from 099b32f are left intact.