### PR TITLE
Update API documentation for supported operating systems and macOS versions

### DIFF
--- a/defender-endpoint/api/offboard-machine-api.md
+++ b/defender-endpoint/api/offboard-machine-api.md
@@ -30,7 +30,7 @@ Offboard device from Defender for Endpoint.
 
 ### Supported operating systems
 
-- This API is supported on Windows 11, Windows 10, version 1703 and later; Windows Server 2019 and later; Windows Server 2012 R2 and Windows Server 2016 when using the [new, unified agent for Defender for Endpoint](../update-agent-mma-windows.md#upgrade-to-the-new-agent-for-defender-for-endpoint).
+- This API is supported on Windows 11, Windows 10, version 1703 and later; Windows Server 2019 and later; Windows Server 2012 R2 and Windows Server 2016 when using the [new, unified agent for Defender for Endpoint](../update-agent-mma-windows.md#upgrade-to-the-new-agent-for-defender-for-endpoint); Supported versions of [macOS](../offboard-machine-api.md#macos-releases)
 
 ## Limitations
 

--- a/defender-endpoint/microsoft-defender-endpoint-releases.md
+++ b/defender-endpoint/microsoft-defender-endpoint-releases.md
@@ -208,7 +208,7 @@ This section covers Microsoft Defender for Endpoint EDR `MsSense.exe` versions. 
 
 ## macOS releases
 
-Defender for Endpoint supports macOS version 15.0.1 or newer. macOS 11 (Big Sur) and 12 (Monterey) are no longer supported.
+Defender for Endpoint supports macOS version 14 (Sonoma) or newer. macOS 11 (Big Sur), 12 (Monterey), 13 (Ventura) are no longer supported.
 
 To share feedback, open Defender for Endpoint on macOS and go to **Help > Send feedback**.
 

--- a/defender-endpoint/microsoft-defender-endpoint-releases.md
+++ b/defender-endpoint/microsoft-defender-endpoint-releases.md
@@ -208,7 +208,7 @@ This section covers Microsoft Defender for Endpoint EDR `MsSense.exe` versions. 
 
 ## macOS releases
 
-Defender for Endpoint supports macOS version 14 (Sonoma) or newer. macOS 11 (Big Sur), 12 (Monterey), 13 (Ventura) are no longer supported.
+Defender for Endpoint supports macOS version 14 (Sonoma) or newer. macOS 11 (Big Sur), 12 (Monterey), and 13 (Ventura) are no longer supported.
 
 To share feedback, open Defender for Endpoint on macOS and go to **Help > Send feedback**.
 


### PR DESCRIPTION
This pull request updates the documentation for Microsoft Defender for Endpoint to clarify and update supported operating systems, with a particular focus on macOS support. The changes ensure users are aware of the latest requirements and compatibility for offboarding devices and using Defender for Endpoint.

**Operating system support updates:**

* Updated the supported operating systems for the Offboard device API to explicitly mention supported versions of macOS, in addition to Windows versions.
* Revised the macOS support statement to indicate that Defender for Endpoint now supports macOS version 14 (Sonoma) or newer, and that macOS 11 (Big Sur), 12 (Monterey), and 13 (Ventura) are no longer supported.