### PR TITLE
Add scoped user recommendations to domain page docs

### DIFF
--- a/defender-for-identity/investigate-domain.md
+++ b/defender-for-identity/investigate-domain.md
@@ -70,6 +70,10 @@ The tab includes default filters for **Status** (New, In progress) and **Alert s
 | **Impacted assets** | The assets affected by the incident. |
 | **Active alerts** | The number of active alerts in the incident. |
 
+## Security recommendations
+
+For scoped users, the domain page shows security recommendations for the domains included in their assigned scope. This view helps scoped users focus on the identity risks that are relevant to the domains they're responsible for. Customers can use this experience to provide domain-level recommendation context without granting broader access across the environment. Each recommendation includes relevant risk information, affected assets, and suggested remediation actions to help scoped users understand what needs attention. By making the right recommendations available to the right users, organizations can improve ownership and move more quickly from visibility to action while maintaining appropriate access boundaries.
+
 ## Security Policies tab
 
 Provides human-readable summaries of key Active Directory security policies in four cards. Use this tab to review critical Active Directory configurations and check whether they meet current security standards.
@@ -125,10 +129,6 @@ Lists the computer accounts in the domain. You can filter by tags. You can mark 
 | **SID** | The Security Identifier of the computer account. |
 | **Canonical Name** | The full canonical name path of the computer in Active Directory. |
 | **Description** | The description of the computer account. |
-
-## Security recommendations
-
-For scoped users, the domain page shows security recommendations for the domains included in their assigned scope. This view helps scoped users focus on the identity risks that are relevant to the domains they're responsible for. Customers can use this experience to provide domain-level recommendation context without granting broader access across the environment. Each recommendation includes relevant risk information, affected assets, and suggested remediation actions to help scoped users understand what needs attention. By making the right recommendations available to the right users, organizations can improve ownership and move more quickly from visibility to action while maintaining appropriate access boundaries.
 
 ## Related content
 

--- a/defender-for-identity/investigate-domain.md
+++ b/defender-for-identity/investigate-domain.md
@@ -4,7 +4,7 @@ description: Learn how to investigate an Active Directory domain in Microsoft De
 #customer intent: As a security admin, I want to view the security posture of my Active Directory domains so that I can identify coverage gaps, review security policies, and act on recommendations.
 author: AbbyMSFT
 ms.author: abbyweisberg
-ms.date: 07/05/2026
+ms.date: 07/29/2026
 ms.topic: concept-article
 ms.service: microsoft-defender-for-identity
 ms.custom: msecd-doc-authoring-106
@@ -49,6 +49,8 @@ The **Overview** tab provides a domain summary.
 | **Sensitive Entities** | Shows the count of sensitive identities, groups, and computers. Select any count to view the details. |
 | **Active Recommendations** | Lists security recommendations that affect the health score, with links to remediation guidance. For example, the **Unsecure Domain Configurations** recommendation links to the corresponding security posture assessment. |
 | **Group Policies** | Lists Group Policy Objects (GPOs) applied in the domain. Use this section to verify active policies and identify domains with no GPOs configured. |
+
+For scoped users, the domain page shows security recommendations for the domains included in their assigned scope. This view helps scoped users focus on the identity risks that are relevant to the domains they're responsible for. Customers can use this experience to provide domain-level recommendation context without granting broader access across the environment. Each recommendation includes relevant risk information, affected assets, and suggested remediation actions to help scoped users understand what needs attention. By making the right recommendations available to the right users, organizations can improve ownership and move more quickly from visibility to action while maintaining appropriate access boundaries.
 
 ## Incidents and alerts tab
 

--- a/defender-for-identity/investigate-domain.md
+++ b/defender-for-identity/investigate-domain.md
@@ -50,6 +50,8 @@ The **Overview** tab provides a domain summary.
 | **Active Recommendations** | Lists security recommendations that affect the health score, with links to remediation guidance. For example, the **Unsecure Domain Configurations** recommendation links to the corresponding security posture assessment. |
 | **Group Policies** | Lists Group Policy Objects (GPOs) applied in the domain. Use this section to verify active policies and identify domains with no GPOs configured. |
 
+## Security recommendations
+
 For scoped users, the domain page shows security recommendations for the domains included in their assigned scope. This view helps scoped users focus on the identity risks that are relevant to the domains they're responsible for. Customers can use this experience to provide domain-level recommendation context without granting broader access across the environment. Each recommendation includes relevant risk information, affected assets, and suggested remediation actions to help scoped users understand what needs attention. By making the right recommendations available to the right users, organizations can improve ownership and move more quickly from visibility to action while maintaining appropriate access boundaries.
 
 ## Incidents and alerts tab

--- a/defender-for-identity/investigate-domain.md
+++ b/defender-for-identity/investigate-domain.md
@@ -50,10 +50,6 @@ The **Overview** tab provides a domain summary.
 | **Active Recommendations** | Lists security recommendations that affect the health score, with links to remediation guidance. For example, the **Unsecure Domain Configurations** recommendation links to the corresponding security posture assessment. |
 | **Group Policies** | Lists Group Policy Objects (GPOs) applied in the domain. Use this section to verify active policies and identify domains with no GPOs configured. |
 
-## Security recommendations
-
-For scoped users, the domain page shows security recommendations for the domains included in their assigned scope. This view helps scoped users focus on the identity risks that are relevant to the domains they're responsible for. Customers can use this experience to provide domain-level recommendation context without granting broader access across the environment. Each recommendation includes relevant risk information, affected assets, and suggested remediation actions to help scoped users understand what needs attention. By making the right recommendations available to the right users, organizations can improve ownership and move more quickly from visibility to action while maintaining appropriate access boundaries.
-
 ## Incidents and alerts tab
 
 Shows all incidents and alerts connected to the domain. Data on this tab includes only incidents and alerts created on or after February 1, 2026.
@@ -129,6 +125,10 @@ Lists the computer accounts in the domain. You can filter by tags. You can mark 
 | **SID** | The Security Identifier of the computer account. |
 | **Canonical Name** | The full canonical name path of the computer in Active Directory. |
 | **Description** | The description of the computer account. |
+
+## Security recommendations
+
+For scoped users, the domain page shows security recommendations for the domains included in their assigned scope. This view helps scoped users focus on the identity risks that are relevant to the domains they're responsible for. Customers can use this experience to provide domain-level recommendation context without granting broader access across the environment. Each recommendation includes relevant risk information, affected assets, and suggested remediation actions to help scoped users understand what needs attention. By making the right recommendations available to the right users, organizations can improve ownership and move more quickly from visibility to action while maintaining appropriate access boundaries.
 
 ## Related content
 


### PR DESCRIPTION
Updates the Active Directory domain investigation article with customer-facing guidance about security recommendations for scoped users on the domain page.