### PR TITLE
Improve macOS performance, NetExt, exclusions, and profile troubleshooting

### DIFF
--- a/defender-endpoint/mac-exclusions.md
+++ b/defender-endpoint/mac-exclusions.md
@@ -12,7 +12,7 @@ ms.collection:
 - mde-macos
 ms.topic: how-to
 ms.subservice: macos
-ms.date: 06/17/2026
+ms.date: 08/11/2026
 appliesto:
   - Microsoft Defender for Endpoint Plan 1
   - Microsoft Defender for Endpoint Plan 2
@@ -33,6 +33,19 @@ To narrow down which process and/or path and/or extension you need to exclude, u
 > Defining exclusions lowers the protection offered by Defender for Endpoint on macOS. You should always evaluate the risks that are associated with implementing exclusions, and you should only exclude files that you're confident aren't malicious.
 
 [!INCLUDE [side-by-side-scenarios](includes/side-by-side-scenarios.md)]
+
+## Choose the appropriate mitigation
+
+Use the narrowest mitigation that addresses the identified component.
+
+| Finding | Appropriate next step |
+|---|---|
+| `wdavdaemon_unprivileged` is affected and real-time protection statistics identify a file, folder, or process | Consider an antivirus exclusion after reviewing the security impact. |
+| `wdavdaemon` or `wdavdaemon_enterprise` is affected | Collect hot event sources and Client Analyzer performance data. Antivirus exclusions might not address this event-processing load. |
+| Another endpoint security product is installed | Confirm the intended active/passive mode and mutual coexistence configuration before adding workload exclusions. |
+| The affected workload isn't identified | Don't add a broad exclusion. Reproduce the issue and collect performance diagnostics first. |
+
+After applying an exclusion, repeat the same workload and compare CPU, memory, scan counts, and elapsed time. Remove the exclusion if it doesn't provide a measurable improvement.
 
 ## Supported exclusion types
 
@@ -176,6 +189,4 @@ For example, to add `EICAR-Test-File (not a virus)` (the threat name associated 
 ```bash
 mdatp threat allowed add --name "EICAR-Test-File (not a virus)"
 ```
-
-
 

--- a/defender-endpoint/mac-exclusions.md
+++ b/defender-endpoint/mac-exclusions.md
@@ -18,7 +18,7 @@ appliesto:
   - Microsoft Defender for Endpoint Plan 2
 
 ai-usage: ai-assisted
-ms.custom: msecd-doc-authoring-1014
+ms.custom: msecd-doc-authoring-1015
 ---
 # Configure and validate exclusions for Microsoft Defender for Endpoint on macOS
 
@@ -34,18 +34,18 @@ To narrow down which process and/or path and/or extension you need to exclude, u
 
 [!INCLUDE [side-by-side-scenarios](includes/side-by-side-scenarios.md)]
 
-## Choose the appropriate mitigation
+## Choose the right mitigation
 
 Use the narrowest mitigation that addresses the identified component.
 
-| Finding | Appropriate next step |
+|Finding|Next step|
 |---|---|
-| `wdavdaemon_unprivileged` is affected and real-time protection statistics identify a file, folder, or process | Consider an antivirus exclusion after reviewing the security impact. |
-| `wdavdaemon` or `wdavdaemon_enterprise` is affected | Collect hot event sources and Client Analyzer performance data. Antivirus exclusions might not address this event-processing load. |
-| Another endpoint security product is installed | Confirm the intended active/passive mode and mutual coexistence configuration before adding workload exclusions. |
-| The affected workload isn't identified | Don't add a broad exclusion. Reproduce the issue and collect performance diagnostics first. |
+|`wdavdaemon_unprivileged` is affected, and real-time protection statistics identify a file, folder, or process|Consider an antivirus exclusion after reviewing the security impact.|
+|`wdavdaemon` or `wdavdaemon_enterprise` is affected|Collect hot event sources and Client Analyzer performance data. Antivirus exclusions might not address this event-processing load.|
+|Another endpoint security product is installed|Confirm the intended active or passive mode and the coexistence settings for both products before adding workload exclusions.|
+|The affected workload isn't identified|Don't add a broad exclusion. Reproduce the issue and collect performance diagnostics first.|
 
-After applying an exclusion, repeat the same workload and compare CPU, memory, scan counts, and elapsed time. Remove the exclusion if it doesn't provide a measurable improvement.
+After applying an exclusion, repeat the same workload and compare CPU usage, memory usage, scan counts, and elapsed time. Remove the exclusion if it doesn't provide a measurable improvement.
 
 ## Supported exclusion types
 
@@ -189,4 +189,3 @@ For example, to add `EICAR-Test-File (not a virus)` (the threat name associated 
 ```bash
 mdatp threat allowed add --name "EICAR-Test-File (not a virus)"
 ```
-

--- a/defender-endpoint/mac-support-perf-overview.md
+++ b/defender-endpoint/mac-support-perf-overview.md
@@ -9,11 +9,12 @@ ms.topic: overview
 ms.localizationpriority: medium
 ms.date: 08/11/2026
 ms.subservice: macos
-ms.custom: partner-contribution
+ms.custom: partner-contribution, msecd-doc-authoring-1015
 appliesto:
   - Microsoft Defender for Endpoint Plan 1
   - Microsoft Defender for Endpoint Plan 2
 
+ai-usage: ai-assisted
 ---
 # Overview for how to troubleshoot performance issues for Microsoft Defender for Endpoint on macOS
 
@@ -33,16 +34,16 @@ Depending on the applications that you're running and your device characteristic
 
 > [!TIP]
 > If you're running other non-Microsoft security products, make sure that the Microsoft Defender for Endpoint on macOS processes and paths are excluded from that non-Microsoft security product and that security product is excluded from Microsoft Defender for Endpoint on macOS. And vice-versa.
+
 When troubleshooting performance issues for Microsoft Defender for Endpoint on macOS, review **Activity Monitor** or run `top` to identify which Defender process has high CPU or memory usage. Collect the data while the performance issue is occurring.
 
-| Daemon name | Component | First troubleshooting step |
+|Daemon name|Component|First troubleshooting step|
 |---|---|---|
-| `wdavdaemon` | Core (privileged) | Collect Client Analyzer performance data and hot event sources. |
-| `wdavdaemon_unprivileged` | Antivirus (AV/EPP) | Use real-time protection statistics to identify files and processes that trigger scans. |
-| `wdavdaemon_enterprise` | Endpoint detection and response (EDR) | Collect Client Analyzer performance data and hot event sources. |
+|`wdavdaemon`|Core (privileged)|Collect Client Analyzer performance data and hot event sources.|
+|`wdavdaemon_unprivileged`|Antivirus and endpoint protection platform (EPP)|Use real-time protection statistics to identify files and processes that trigger scans.|
+|`wdavdaemon_enterprise`|Endpoint detection and response (EDR)|Collect Client Analyzer performance data and hot event sources.|
 
-For all three processes, record the process name, CPU and memory use, duration, device model and processor, Defender version, macOS version, enforcement mode, workload, and other security products. Gather [Defender for Endpoint Client Analyzer](overview-client-analyzer.md) files while the issue occurs.
+For all three processes, record the process name, CPU and memory use, duration, device model and processor, Defender version, macOS version, enforcement mode, workload, and other security products. Gather [Microsoft Defender for Endpoint Client Analyzer](overview-client-analyzer.md) files while the issue occurs.
 
 > [!IMPORTANT]
 > Antivirus exclusions affect antivirus scanning. They don't exclude activity from EDR or other Endpoint Security event processing. If an antivirus exclusion doesn't improve performance, don't broaden the exclusion without first identifying the affected component.
-

--- a/defender-endpoint/mac-support-perf-overview.md
+++ b/defender-endpoint/mac-support-perf-overview.md
@@ -7,7 +7,7 @@ ms.reviewer: joshbregman
 ms.service: defender-endpoint
 ms.topic: overview
 ms.localizationpriority: medium
-ms.date: 04/16/2025
+ms.date: 08/11/2026
 ms.subservice: macos
 ms.custom: partner-contribution
 appliesto:
@@ -33,14 +33,16 @@ Depending on the applications that you're running and your device characteristic
 
 > [!TIP]
 > If you're running other non-Microsoft security products, make sure that the Microsoft Defender for Endpoint on macOS processes and paths are excluded from that non-Microsoft security product and that security product is excluded from Microsoft Defender for Endpoint on macOS. And vice-versa.
-When troubleshooting performance issues for Microsoft Defender for Endpoint on macOS, you should review the **Activity Monitor** or run **top** to see which of the three (3) processes is leading the high cpu utilization
+When troubleshooting performance issues for Microsoft Defender for Endpoint on macOS, review **Activity Monitor** or run `top` to identify which Defender process has high CPU or memory usage. Collect the data while the performance issue is occurring.
 
-|Daemon name|Component|Troubleshooting guide|
-| -------- | -------- |-------- |
-|wdavdaemon| Core (privileged)|Open a [Microsoft support case](contact-support.md).|
-|wdavdaemon_unprivileged| Anti-malware (AV, EPP)|Review [Troubleshoot performance issues for Microsoft Defender for Endpoint on macOS](mac-support-perf.md).|
-|wdavdaemon_enterprise| Endpoint Detection and Response (EDR)|Open a [Microsoft support case](contact-support.md).|
+| Daemon name | Component | First troubleshooting step |
+|---|---|---|
+| `wdavdaemon` | Core (privileged) | Collect Client Analyzer performance data and hot event sources. |
+| `wdavdaemon_unprivileged` | Antivirus (AV/EPP) | Use real-time protection statistics to identify files and processes that trigger scans. |
+| `wdavdaemon_enterprise` | Endpoint detection and response (EDR) | Collect Client Analyzer performance data and hot event sources. |
 
-Additionally, gather [Defender for Endpoint Client Analyzer](overview-client-analyzer.md) files while the issue occurs. This is used by the support team to investigate the issue. 
+For all three processes, record the process name, CPU and memory use, duration, device model and processor, Defender version, macOS version, enforcement mode, workload, and other security products. Gather [Defender for Endpoint Client Analyzer](overview-client-analyzer.md) files while the issue occurs.
 
+> [!IMPORTANT]
+> Antivirus exclusions affect antivirus scanning. They don't exclude activity from EDR or other Endpoint Security event processing. If an antivirus exclusion doesn't improve performance, don't broaden the exclusion without first identifying the affected component.
 

--- a/defender-endpoint/mac-support-perf.md
+++ b/defender-endpoint/mac-support-perf.md
@@ -12,7 +12,7 @@ ms.collection:
 - mde-macos
 ms.topic: troubleshooting-general
 ms.subservice: macos
-ms.date: 06/20/2025
+ms.date: 08/11/2026
 appliesto:
   - Microsoft Defender for Endpoint Plan 1
   - Microsoft Defender for Endpoint Plan 2
@@ -56,7 +56,7 @@ To troubleshoot and mitigate performance issues, follow these steps:
    | Device isn't managed by organization | **Terminal**: In Terminal, run the following command: `mdatp config real-time-protection --value disabled` |
    | Device is managed by organization | See [Set preferences for Microsoft Defender for Endpoint on macOS](mac-preferences.md). |
    
-   If the performance problem persists while real-time protection is off, the origin of the problem could be the endpoint detection and response component. In this case, contact customer support for further instructions and mitigation.
+   If the performance problem persists while real-time protection is off, the issue isn't limited to antivirus scanning. Continue with [Troubleshoot core or EDR performance issues](#troubleshoot-core-or-edr-performance-issues).
    
 1. Open Finder and navigate to **Applications** > **Utilities**. Open **Activity Monitor** and analyze which applications are using the resources on your system. Typical examples include software updaters and compilers.
 
@@ -152,6 +152,26 @@ To troubleshoot and mitigate performance issues, follow these steps:
 
 See the guide on our support page for [Behavior Monitoring](behavior-monitor-macos.md).
 
+## Troubleshoot core or EDR performance issues
+
+Use this workflow when high resource use occurs in `wdavdaemon` or `wdavdaemon_enterprise`, or when the issue continues while real-time protection is disabled.
+
+1. Reproduce the issue and confirm the affected Defender process in Activity Monitor or by running `top`.
+1. Record the workload that is running, the start and end time, CPU and memory use, device model and processor, macOS version, Defender version, enforcement mode, and any other security or monitoring products.
+1. Collect hot event sources during the affected period:
+
+   ```bash
+   sudo mdatp diagnostic hot-event-sources --time=360
+   ```
+
+   The command creates a report that identifies applications and processes producing the most Endpoint Security events. Run the collection only while the issue is occurring.
+1. Run the Microsoft Defender for Endpoint Client Analyzer performance collection as described in [Run the client analyzer on macOS and Linux](overview-client-analyzer.md).
+1. If another endpoint security product is installed, confirm that the products are configured for the intended coexistence mode. See [Microsoft Defender for Endpoint and other security solutions](mde-side-by-side.md).
+1. Contact Microsoft support and provide the process measurements, hot event source report, Client Analyzer output, and exact reproduction window.
+
+> [!IMPORTANT]
+> An antivirus exclusion doesn't suppress EDR or other Endpoint Security events. Don't add broad antivirus exclusions to address `wdavdaemon` or `wdavdaemon_enterprise` resource use unless antivirus scanning is also identified as a contributor.
+
 ## Troubleshoot performance issues using Microsoft Defender for Endpoint Client Analyzer
 
 The Microsoft Defender for Endpoint Client Analyzer (MDECA) can collect traces, logs, and diagnostic information in order to troubleshoot performance issues on [onboarded devices](onboard-configure.md) on macOS.
@@ -160,4 +180,3 @@ To run the client analyzer for troubleshooting performance issues, see [Run the 
 
 > [!NOTE]
 > The Microsoft Defender for Endpoint Client Analyzer tool is regularly used by Microsoft Customer Support Services (CSS) to collect information such as (but not limited    to) IP addresses, PC names that help troubleshoot issues you might be experiencing with Microsoft Defender for Endpoint. For more information about our privacy statement, see [Microsoft Privacy Statement](https://privacy.microsoft.com/privacystatement).
-

--- a/defender-endpoint/mac-support-perf.md
+++ b/defender-endpoint/mac-support-perf.md
@@ -18,6 +18,8 @@ appliesto:
   - Microsoft Defender for Endpoint Plan 2
   - Microsoft Defender for Individuals
 
+ai-usage: ai-assisted
+ms.custom: msecd-doc-authoring-1015
 ---
 # Troubleshoot performance issues for Microsoft Defender for Endpoint on macOS
 
@@ -56,7 +58,7 @@ To troubleshoot and mitigate performance issues, follow these steps:
    | Device isn't managed by organization | **Terminal**: In Terminal, run the following command: `mdatp config real-time-protection --value disabled` |
    | Device is managed by organization | See [Set preferences for Microsoft Defender for Endpoint on macOS](mac-preferences.md). |
    
-   If the performance problem persists while real-time protection is off, the issue isn't limited to antivirus scanning. Continue with [Troubleshoot core or EDR performance issues](#troubleshoot-core-or-edr-performance-issues).
+   If the performance problem persists while real-time protection is off, the issue isn't limited to antivirus scanning. Continue with [Troubleshoot core or endpoint detection and response performance issues](#troubleshoot-core-or-endpoint-detection-and-response-performance-issues).
    
 1. Open Finder and navigate to **Applications** > **Utilities**. Open **Activity Monitor** and analyze which applications are using the resources on your system. Typical examples include software updaters and compilers.
 
@@ -152,12 +154,21 @@ To troubleshoot and mitigate performance issues, follow these steps:
 
 See the guide on our support page for [Behavior Monitoring](behavior-monitor-macos.md).
 
-## Troubleshoot core or EDR performance issues
+## Troubleshoot core or endpoint detection and response performance issues
 
-Use this workflow when high resource use occurs in `wdavdaemon` or `wdavdaemon_enterprise`, or when the issue continues while real-time protection is disabled.
+Use this workflow when `wdavdaemon` or `wdavdaemon_enterprise` has high resource use, or when the issue continues while real-time protection is disabled.
 
-1. Reproduce the issue and confirm the affected Defender process in Activity Monitor or by running `top`.
-1. Record the workload that is running, the start and end time, CPU and memory use, device model and processor, macOS version, Defender version, enforcement mode, and any other security or monitoring products.
+1. Reproduce the issue and confirm the affected Defender process in **Activity Monitor** or by running `top`.
+1. Record the following information:
+
+   - Workload.
+   - Start and end times.
+   - CPU and memory use.
+   - Device model and processor.
+   - macOS and Defender versions.
+   - Enforcement mode.
+   - Other security or monitoring products.
+
 1. Collect hot event sources during the affected period:
 
    ```bash
@@ -165,9 +176,9 @@ Use this workflow when high resource use occurs in `wdavdaemon` or `wdavdaemon_e
    ```
 
    The command creates a report that identifies applications and processes producing the most Endpoint Security events. Run the collection only while the issue is occurring.
-1. Run the Microsoft Defender for Endpoint Client Analyzer performance collection as described in [Run the client analyzer on macOS and Linux](overview-client-analyzer.md).
+1. Collect performance data by following the instructions in [Run the client analyzer on macOS and Linux](overview-client-analyzer.md).
 1. If another endpoint security product is installed, confirm that the products are configured for the intended coexistence mode. See [Microsoft Defender for Endpoint and other security solutions](mde-side-by-side.md).
-1. Contact Microsoft support and provide the process measurements, hot event source report, Client Analyzer output, and exact reproduction window.
+1. Contact Microsoft Support and provide the process measurements, hot event source report, Client Analyzer output, and exact time window when you reproduced the issue.
 
 > [!IMPORTANT]
 > An antivirus exclusion doesn't suppress EDR or other Endpoint Security events. Don't add broad antivirus exclusions to address `wdavdaemon` or `wdavdaemon_enterprise` resource use unless antivirus scanning is also identified as a contributor.

--- a/defender-endpoint/mac-support-sys-ext.md
+++ b/defender-endpoint/mac-support-sys-ext.md
@@ -12,7 +12,7 @@ ms.collection:
 - mde-macos
 ms.topic: troubleshooting-general
 ms.subservice: macos
-ms.date: 04/16/2025
+ms.date: 08/11/2026
 appliesto:
   - Microsoft Defender for Endpoint Plan 1
   - Microsoft Defender for Endpoint Plan 2
@@ -145,8 +145,8 @@ If you're using Intune, see [Manage macOS software update policies in Intune](/i
 
    :::image type="content" source="media/screen-on-clicking-refresh-devices.png" alt-text="The screen that appears on clicking Refresh devices." lightbox="media/screen-on-clicking-refresh-devices.png":::
 
-1. In Launchpad, type **System Preferences**.
-1. Double-click **Profiles**.
+1. Open **System Settings**.
+1. Select **General** > **Device Management** to review installed management profiles. The exact location can vary by macOS version.
 
    > [!NOTE]
    > If you aren't MDM joined, you won't see **Profiles** as an option.  Contact your MDM support team to see why the **Profiles** option isn't visible. You should be able to see the different profiles such as **System Extensions**, **Accessibility**, **Background Services**, **Notifications**, **Microsoft AutoUpdate**, and so on, as shown in the preceding screenshot.
@@ -163,6 +163,9 @@ The section [Sections that provide guidance on enabling profiles needed for Micr
 > For example: `FullDiskAccess (piloting) - macOS - Default - MDE`
 
 Using the recommended naming convention enables you to confirm that the correct profiles are dropping down at the time of checking.
+
+> [!IMPORTANT]
+> Deploy each Defender for Endpoint mobile configuration as the separate payload provided for that setting. Don't combine the onboarding, system extension, network filter, privacy preference, background service, notification, or accessibility payloads into one custom payload. A merged or structurally modified payload can be accepted by the management service but ignored by macOS or Defender for Endpoint.
 
 > [!TIP]
 > To ensure that the correct profiles are coming down, instead of typing.mobileconfig (plist)**, you can download this profile from GitHub, to avoid typos elongated hyphens.
@@ -260,12 +263,10 @@ The tool compares your profiles with what we have published in GitHub, and repor
 
      OR
 
-     - Run the script directly from the Web by running the following commands:
+     - Run the script directly from the web:
 
        ```bash
-       sudo curl https://raw.githubusercontent.com/microsoft/mdatp-xplat/master/macos/mdm/analyze_profiles.py
-
-       | python3 -
+       curl -fsSL https://raw.githubusercontent.com/microsoft/mdatp-xplat/master/macos/mdm/analyze_profiles.py | sudo python3 -
        ```
 
 The output shows all potential issues with profiles.

--- a/defender-endpoint/mac-support-sys-ext.md
+++ b/defender-endpoint/mac-support-sys-ext.md
@@ -16,7 +16,9 @@ ms.date: 08/11/2026
 appliesto:
   - Microsoft Defender for Endpoint Plan 1
   - Microsoft Defender for Endpoint Plan 2
-ms.custom: sfi-image-nochange
+
+ai-usage: ai-assisted
+ms.custom: sfi-image-nochange, msecd-doc-authoring-1015
 ---
 
 # Troubleshoot system extension issues in Microsoft Defender for Endpoint on macOS
@@ -165,7 +167,7 @@ The section [Sections that provide guidance on enabling profiles needed for Micr
 Using the recommended naming convention enables you to confirm that the correct profiles are dropping down at the time of checking.
 
 > [!IMPORTANT]
-> Deploy each Defender for Endpoint mobile configuration as the separate payload provided for that setting. Don't combine the onboarding, system extension, network filter, privacy preference, background service, notification, or accessibility payloads into one custom payload. A merged or structurally modified payload can be accepted by the management service but ignored by macOS or Defender for Endpoint.
+> Deploy each Defender for Endpoint mobile configuration as a separate payload provided for that setting. Don't combine the onboarding, system extension, network filter, privacy preferences, background service, notification, or accessibility payloads into one custom payload. The management service might accept a merged or structurally modified payload, but macOS or Defender for Endpoint might ignore it.
 
 > [!TIP]
 > To ensure that the correct profiles are coming down, instead of typing.mobileconfig (plist)**, you can download this profile from GitHub, to avoid typos elongated hyphens.

--- a/defender-endpoint/mac-troubleshoot-netext-mde.md
+++ b/defender-endpoint/mac-troubleshoot-netext-mde.md
@@ -12,7 +12,7 @@ ms.collection:
 - mde-macos
 ms.topic: troubleshooting-general
 ms.subservice: macos
-ms.date: 04/16/2025
+ms.date: 08/11/2026
 appliesto:
   - Microsoft Defender for Endpoint Plan 1
   - Microsoft Defender for Endpoint Plan 2
@@ -28,13 +28,51 @@ appliesto:
 
 This article provides information on how to troubleshoot issues with the network extension (NetExt) that's installed as part of Microsoft Defender for Endpoint on macOS. 
 
-NetExt is used by [Network Protection](network-protection-macos.md) is enabled on Mac devices.
+NetExt provides network event data used by multiple Defender for Endpoint capabilities. [Network Protection](network-protection-macos.md) depends on NetExt, but disabling Network Protection enforcement isn't the same as disabling NetExt.
 
 **Symptom**: 
 
 You might notice issues with network related latencies when using your browser or copying files over the network or using a chat/meeting application. 
 
-**Temporary solution**:
+## Identify the affected component
+
+Before disabling NetExt, determine whether the issue requires Network Protection enforcement or only the network extension to be running.
+
+1. Check Network Protection and system extension health:
+
+   ```bash
+   mdatp health --field network_protection_status
+   mdatp health --details system_extensions
+   mdatp health --details network_protection
+   ```
+
+1. Test the following states and record whether the issue reproduces:
+
+   | NetExt | Network Protection | Interpretation |
+   |---|---|---|
+   | Enabled | Audit or block | Baseline with both components active |
+   | Enabled | Disabled | If the issue remains, investigate NetExt or another capability that uses network events |
+   | Disabled | Disabled | If the issue stops only here, NetExt is involved |
+
+1. Record the affected application and protocol, browser or client, destination, proxy configuration, VPN product and full-tunnel or split-tunnel mode, and whether other network-filtering security products are installed.
+1. Collect a diagnostic package while reproducing the issue:
+
+   ```bash
+   sudo mdatp diagnostic create
+   ```
+
+   If Microsoft support requests a NetExt log stream, run:
+
+   ```bash
+   log stream --info --debug --style compact --predicate 'process == "netext"' > netextlogstream.txt
+   ```
+
+   Reproduce the issue, and then press **Control+C** to stop the trace.
+
+> [!CAUTION]
+> Disabling NetExt reduces network visibility and disables capabilities that depend on network events. Use the smallest possible pilot group, record the original assignment, and restore the configuration after testing.
+
+## Temporary solution
 
 This article describes how to temporarily disable NetExt which will temporarily disable network protection, and resolve network stack-related issues by using Intune, JamF, or a manual process on macOS.
 

--- a/defender-endpoint/mac-troubleshoot-netext-mde.md
+++ b/defender-endpoint/mac-troubleshoot-netext-mde.md
@@ -17,6 +17,8 @@ appliesto:
   - Microsoft Defender for Endpoint Plan 1
   - Microsoft Defender for Endpoint Plan 2
 
+ai-usage: ai-assisted
+ms.custom: msecd-doc-authoring-1015
 ---
 # Troubleshoot Network Extension (NetExt) issues in Defender for Endpoint on Mac 
 
@@ -28,7 +30,7 @@ appliesto:
 
 This article provides information on how to troubleshoot issues with the network extension (NetExt) that's installed as part of Microsoft Defender for Endpoint on macOS. 
 
-NetExt provides network event data used by multiple Defender for Endpoint capabilities. [Network Protection](network-protection-macos.md) depends on NetExt, but disabling Network Protection enforcement isn't the same as disabling NetExt.
+NetExt provides network event data that multiple Defender for Endpoint capabilities use. [Network Protection](network-protection-macos.md) depends on NetExt, but disabling Network Protection enforcement isn't the same as disabling NetExt.
 
 **Symptom**: 
 
@@ -36,9 +38,9 @@ You might notice issues with network related latencies when using your browser o
 
 ## Identify the affected component
 
-Before disabling NetExt, determine whether the issue requires Network Protection enforcement or only the network extension to be running.
+Before disabling NetExt, determine whether the issue occurs only when Network Protection enforcement is enabled or whenever NetExt is running.
 
-1. Check Network Protection and system extension health:
+1. Check Network Protection and system extension health to establish a baseline:
 
    ```bash
    mdatp health --field network_protection_status
@@ -48,20 +50,28 @@ Before disabling NetExt, determine whether the issue requires Network Protection
 
 1. Test the following states and record whether the issue reproduces:
 
-   | NetExt | Network Protection | Interpretation |
+   |NetExt|Network Protection|Interpretation|
    |---|---|---|
-   | Enabled | Audit or block | Baseline with both components active |
-   | Enabled | Disabled | If the issue remains, investigate NetExt or another capability that uses network events |
-   | Disabled | Disabled | If the issue stops only here, NetExt is involved |
+   |Enabled|Audit or block|Baseline with both components active.|
+   |Enabled|Disabled|If the issue remains, investigate NetExt or another capability that uses network events.|
+   |Disabled|Disabled|If the issue stops only here, NetExt is involved.|
 
-1. Record the affected application and protocol, browser or client, destination, proxy configuration, VPN product and full-tunnel or split-tunnel mode, and whether other network-filtering security products are installed.
+1. Record the following information:
+
+   - Affected application and protocol.
+   - Browser or client.
+   - Destination.
+   - Proxy configuration.
+   - Virtual private network (VPN) product and full-tunnel or split-tunnel mode.
+   - Other installed network-filtering security products.
+
 1. Collect a diagnostic package while reproducing the issue:
 
    ```bash
    sudo mdatp diagnostic create
    ```
 
-   If Microsoft support requests a NetExt log stream, run:
+   If Microsoft Support requests a NetExt log stream, run:
 
    ```bash
    log stream --info --debug --style compact --predicate 'process == "netext"' > netextlogstream.txt


### PR DESCRIPTION
## Summary
- add first-touch diagnostics for core and EDR performance issues
- clarify AV exclusion scope and evidence-based mitigation selection
- add NetExt versus Network Protection isolation and trace collection
- modernize system-extension/profile validation and warn against merged payloads
- update article review dates

## Why
Current guidance frequently routes core/EDR and network-extension issues directly to support without a complete diagnostic package. These changes help customers and support identify the affected component before applying broad exclusions or disabling protection.

## Validation
- `git diff --check`
- verified new relative links and existing article targets
- no internal feature flags, tenant details, engineering overrides, or restricted diagnostics included