### PR TITLE
[Wait for Engineering Review] Align macOS troubleshooting guidance with coexistence and exclusion principles

### DIFF
--- a/defender-endpoint/mac-exclusions.md
+++ b/defender-endpoint/mac-exclusions.md
@@ -23,7 +23,7 @@ ms.custom: msecd-doc-authoring-1015
 # Configure and validate exclusions for Microsoft Defender for Endpoint on macOS
 
 
-This article provides information on how to define exclusions that apply to on-demand scans, and real-time protection and monitoring. The scan exclusions described in this article don't apply to other Defender for Endpoint on macOS capabilities, including endpoint detection and response (EDR). Files that you exclude using the methods described in this article can still trigger EDR alerts and other detections.
+This article provides information on how to define exclusions that apply to on-demand scans, and real-time protection and monitoring. The scan exclusions described in this article don't apply to endpoint detection and response (EDR). Files that you exclude using the methods described in this article can still trigger EDR alerts and other detections. Process exclusions also prevent Network Protection from inspecting traffic or enforcing rules for the excluded process.
 
 You can exclude certain files, folders, processes, and process-opened files from Defender for Endpoint on macOS scans. Exclusions can help avoid incorrect detections on files and software that are unique to your organization. Exclusions can also be useful for mitigating performance issues caused by Defender for Endpoint on macOS.
 
@@ -42,10 +42,12 @@ Use the narrowest mitigation that addresses the identified component.
 |---|---|
 |`wdavdaemon_unprivileged` is affected, and real-time protection statistics identify a file, folder, or process|Consider an antivirus exclusion after reviewing the security impact.|
 |`wdavdaemon` or `wdavdaemon_enterprise` is affected|Collect hot event sources and Client Analyzer performance data. Antivirus exclusions might not address this event-processing load.|
-|Another endpoint security product is installed|Confirm the intended active or passive mode and the coexistence settings for both products before adding workload exclusions.|
+|Another endpoint security product is installed|Identify which product provides active antivirus protection and confirm the intended Defender enforcement mode. Review supported coexistence guidance, and use mutual exclusions only when required for a confirmed interoperability issue.|
 |The affected workload isn't identified|Don't add a broad exclusion. Reproduce the issue and collect performance diagnostics first.|
 
 After applying an exclusion, repeat the same workload and compare CPU usage, memory usage, scan counts, and elapsed time. Remove the exclusion if it doesn't provide a measurable improvement.
+
+Use fully qualified paths when possible so that you exclude only the intended item. Before adding an exclusion, review [Exclusions to avoid in Microsoft Defender Antivirus and Defender for Endpoint](defender-endpoint-exclusions-common-mistakes.md).
 
 ## Supported exclusion types
 

--- a/defender-endpoint/mac-support-perf-overview.md
+++ b/defender-endpoint/mac-support-perf-overview.md
@@ -30,10 +30,10 @@ Depending on the applications that you're running and your device characteristic
 > Running other non-Microsoft endpoint protection products alongside Microsoft Defender for Endpoint on macOS is likely to lead to performance problems and unpredictable side effects. If non-Microsoft endpoint protection is an absolute requirement in your environment, you can configure Microsoft Defender Antivirus to run in **[Passive mode](mac-preferences.md)**. After you configure Passive mode, you can use Defender for Endpoint on macOS EDR functionality.
 
 > [!WARNING]
-> Before starting, make sure that other security products aren't currently running on the device. Multiple security products might conflict and affect system performance.
+> Before starting, identify which security product provides active antivirus protection and confirm the intended Defender enforcement mode. Avoid running overlapping active protection capabilities because they can conflict and affect system performance. For more information, see [Microsoft Defender for Endpoint alongside other security solutions](mde-side-by-side.md).
 
 > [!TIP]
-> If you're running other non-Microsoft security products, make sure that the Microsoft Defender for Endpoint on macOS processes and paths are excluded from that non-Microsoft security product and that security product is excluded from Microsoft Defender for Endpoint on macOS. And vice-versa.
+> If you're running other non-Microsoft security products, review the vendor-specific coexistence guidance. Mutual exclusions can help address a confirmed interoperability issue, but they reduce protection. Exclude only trusted processes and paths, and validate that the exclusions provide a measurable improvement.
 
 When troubleshooting performance issues for Microsoft Defender for Endpoint on macOS, review **Activity Monitor** or run `top` to identify which Defender process has high CPU or memory usage. Collect the data while the performance issue is occurring.
 
@@ -46,4 +46,4 @@ When troubleshooting performance issues for Microsoft Defender for Endpoint on m
 For all three processes, record the process name, CPU and memory use, duration, device model and processor, Defender version, macOS version, enforcement mode, workload, and other security products. Gather [Microsoft Defender for Endpoint Client Analyzer](overview-client-analyzer.md) files while the issue occurs.
 
 > [!IMPORTANT]
-> Antivirus exclusions affect antivirus scanning. They don't exclude activity from EDR or other Endpoint Security event processing. If an antivirus exclusion doesn't improve performance, don't broaden the exclusion without first identifying the affected component.
+> File, folder, and file extension exclusions affect antivirus scanning. Process exclusions also prevent Network Protection from inspecting traffic or enforcing rules for the excluded process. These exclusions don't suppress EDR visibility or other Endpoint Security event processing. If an exclusion doesn't improve performance, don't broaden it without first identifying the affected component.

--- a/defender-endpoint/mac-support-perf.md
+++ b/defender-endpoint/mac-support-perf.md
@@ -30,7 +30,7 @@ This article provides some general steps that can be used to narrow down perform
 Depending on the applications that you're running and your device characteristics, you might experience suboptimal performance when running Microsoft Defender for Endpoint on macOS. In particular, applications or system processes that access many resources over a short timespan can lead to performance issues in Defender for Endpoint on macOS.
 
 > [!WARNING]
-> Before you perform the procedures described in this article, make sure that other security products aren't currently running on the device. Multiple security products can conflict and affect the host performance.
+> Before you perform the procedures described in this article, identify which security product provides active antivirus protection and confirm the intended Defender enforcement mode. Avoid running overlapping active protection capabilities because they can conflict and affect performance. For more information, see [Microsoft Defender for Endpoint alongside other security solutions](mde-side-by-side.md).
 
 ## Troubleshoot performance issues using real-time protection statistics
 
@@ -50,7 +50,7 @@ Prerequisites:
 
 To troubleshoot and mitigate performance issues, follow these steps:
 
-1. Disable real-time protection by using one of the methods in the following table, and then observe whether performance improves. This approach helps narrow down whether Microsoft Defender for Endpoint on macOS is contributing to the performance issues.
+1. Temporarily disable real-time protection by using one of the methods in the following table, and then observe whether performance improves. This approach helps narrow down whether Microsoft Defender Antivirus on macOS is contributing to the performance issues. Record the original setting and restore it immediately after the test.
 
    | Device management | Method |
    |---|--|
@@ -181,7 +181,7 @@ Use this workflow when `wdavdaemon` or `wdavdaemon_enterprise` has high resource
 1. Contact Microsoft Support and provide the process measurements, hot event source report, Client Analyzer output, and exact time window when you reproduced the issue.
 
 > [!IMPORTANT]
-> An antivirus exclusion doesn't suppress EDR or other Endpoint Security events. Don't add broad antivirus exclusions to address `wdavdaemon` or `wdavdaemon_enterprise` resource use unless antivirus scanning is also identified as a contributor.
+> File, folder, and file extension exclusions don't suppress EDR or other Endpoint Security events. Process exclusions also prevent Network Protection from inspecting traffic or enforcing rules for the excluded process. Don't add broad antivirus exclusions to address `wdavdaemon` or `wdavdaemon_enterprise` resource use unless antivirus scanning is also identified as a contributor.
 
 ## Troubleshoot performance issues using Microsoft Defender for Endpoint Client Analyzer
 

--- a/defender-endpoint/mac-troubleshoot-netext-mde.md
+++ b/defender-endpoint/mac-troubleshoot-netext-mde.md
@@ -46,7 +46,10 @@ Before disabling NetExt, determine whether the issue occurs only when Network Pr
    mdatp health --field network_protection_status
    mdatp health --details system_extensions
    mdatp health --details network_protection
+   mdatp connectivity test
    ```
+
+   Resolve any connectivity test failures before isolating Network Protection or NetExt.
 
 1. Test the following states and record whether the issue reproduces:
 
@@ -79,8 +82,11 @@ Before disabling NetExt, determine whether the issue occurs only when Network Pr
 
    Reproduce the issue, and then press **Control+C** to stop the trace.
 
+   > [!CAUTION]
+   > NetExt log streams can contain hostnames, URLs, IP addresses, and other environment details. Collect a log stream only when Microsoft support requests it, and transfer it by using the support-approved upload method.
+
 > [!CAUTION]
-> Disabling NetExt reduces network visibility and disables capabilities that depend on network events. Use the smallest possible pilot group, record the original assignment, and restore the configuration after testing.
+> Disabling NetExt reduces network visibility and disables capabilities that depend on network events. Use the smallest possible pilot group and record the original Network Protection and NetExt assignments. At the end of testing, restore both components to their original assignments and verify their health.
 
 ## Temporary solution
 


### PR DESCRIPTION
## Summary

Follow-up to #574 that aligns macOS troubleshooting messaging with the cross-platform and Windows guidance while preserving macOS-specific behavior.

- Clarifies that coexistence configuration is capability- and risk-based rather than requiring blanket mutual exclusions.
- Documents the Network Protection effect of process exclusions while retaining EDR visibility.
- Makes temporary protection-disable tests explicitly restore the original state.
- Adds connectivity validation and safe handling guidance for NetExt diagnostics.
- Links to the cross-platform exclusions-to-avoid guidance.