### PR TITLE
Add Remote tenant group (GDAP) option to URBAC custom role assignment

### DIFF
--- a/defender-xdr/create-custom-rbac-roles.md
+++ b/defender-xdr/create-custom-rbac-roles.md
@@ -10,7 +10,7 @@ ms.collection:
 - tier3
 ms.custom: msecd-doc-authoring-1014
 ms.topic: how-to
-ms.date: 06/16/2026
+ms.date: 08/25/2026
 ms.reviewer: 
 appliesto:
 - Microsoft Defender for Endpoint Plan 2
@@ -88,6 +88,8 @@ The following steps describe how to create custom roles in the Microsoft Defende
 
         - **Assignment name**: Enter a descriptive name for the assignment.
         - **Employees**: Select Microsoft Entra security groups or individual users to assign users to the role.
+        - **Remote tenant group**: Select one or more GDAP remote tenant groups to assign to this role. Users who are members of the selected remote tenant groups inherit the permissions, data source access, and applicable scopes configured in this assignment. This option enables organizations to extend Microsoft Defender unified RBAC permissions to external tenants through an established GDAP relationship.
+
         - **Data sources**: Select the **Data sources** drop down and then select the services where the assigned users will have the selected permissions. If you assigned read-only permissions for a single data source, such as Microsoft Defender for Endpoint, the assigned users can't read alerts in the other services, such as Microsoft Defender for Office 365 or Microsoft Defender for Identity.
         - **Data collections**: Users assigned in this assignment can be granted permissions either across all available Sentinel workspaces or only to selected workspaces. For example, if a role with 'Security operations - read only permission' is created, one team may be assigned this role for US-Workspace and UK-Workspace, allowing them to access all alerts from these sources. Another assignment can be created for the same role, providing another team in the organization access to only UK-Workspace alerts from Sentinel UK-Workspace.
 


### PR DESCRIPTION
## What
Adds a new bullet under Step 7 ("Add assignment" side pane) documenting the **Remote tenant group** option for GDAP-based cross-tenant URBAC assignment.

## Why
Feature ships to customers on **2026-08-25** and needs public documentation live on the same day.

## Changes
- Added `Remote tenant group` bullet between `Employees` and `Data sources` in the Add assignment side pane list.
- Bumped `ms.date` to `08/25/2026`.

## Attribution
Content contributed by **Izabella** (Robi Czitron's group). Submitting on her behalf.

## Review
/cc @mberdugo — please review for content accuracy and voice.

Target go-live: **Tuesday, August 25, 2026**.

